### PR TITLE
Issue 128 rename attributes

### DIFF
--- a/nlptest/nlptest.py
+++ b/nlptest/nlptest.py
@@ -91,7 +91,7 @@ class Harness:
             None: The generated testcases are stored in `_testcases` attribute.
         """
         tests = self._config['tests']
-        self.load_testcases = TestFactory.transform(self.data, tests)
+        self._testcases = TestFactory.transform(self.data, tests)
         return self
 
     def run(self) -> "Harness":


### PR DESCRIPTION
fixes #128

- load_testcases -> _testcases
- load_testcases_df -> testcases
- generated_results -> _generated_results
- generated_results_df -> generated_results

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've added Google style docstrings to my code.
- [x] I've used `pydantic` for typing when/where necessary.
- [x] I have linted my code
- [x] I have added tests to cover my changes.