### PR TITLE
chore: save/load testcases to pickle

### DIFF
--- a/nlptest/nlptest.py
+++ b/nlptest/nlptest.py
@@ -154,7 +154,7 @@ class Harness:
         return self.df_report
 
         # return self.report_df
-    
+
     def generated_results_df(self) -> pd.DataFrame:
         """
         Generates an overall report with every textcase and labelwise metrics.
@@ -210,9 +210,9 @@ class Harness:
         """
 
         dtypes = list(map(
-            lambda x: str(x), 
+            lambda x: str(x),
             self.df_report[['pass_rate', 'minimum_pass_rate']].dtypes.values.tolist()))
-        if dtypes not in [['int64']*2, ['int32']*2]:
+        if dtypes not in [['int64'] * 2, ['int32'] * 2]:
             self.df_report['pass_rate'] = self.df_report['pass_rate'].str.replace("%", "").astype(int)
             self.df_report['minimum_pass_rate'] = self.df_report['minimum_pass_rate'].str.replace("%", "").astype(int)
         _ = AugmentRobustness(
@@ -263,6 +263,23 @@ class Harness:
         with open(os.path.join(save_dir, "data.pkl"), "wb") as writer:
             pickle.dump(self.data, writer)
 
+    def save_testcases(self, path_to_file: str) -> None:
+        """
+        Save the generated testcases into a pickle file.
+
+        Args:
+            path_to_file (str):
+                location to save the pickle file to
+        Returns:
+
+        """
+        if self._testcases is None:
+            raise ValueError("The test cases have not been generated yet. Please use the `.generate` method before"
+                             "calling the `.save` method.")
+
+        with open(path_to_file, "wb") as writer:
+            pickle.dump(self._testcases, writer)
+
     @classmethod
     def load(cls, save_dir: str, task: str, model: Union[str, 'ModelFactory'], hub: str = None) -> 'Harness':
         """
@@ -295,3 +312,16 @@ class Harness:
             harness.data = pickle.load(reader)
 
         return harness
+
+    def load_testcases(self, path_to_file: str) -> None:
+        """
+        Loads the testcases from a pickle file
+
+        Args:
+            path_to_file (str):
+                location to load the test cases from
+        Returns:
+
+        """
+        with open(path_to_file, "rb") as reader:
+            self._testcases = pickle.load(reader)

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -30,7 +30,8 @@ class HarnessTestCase(unittest.TestCase):
     def test_missing_parameter(self):
         """"""
         with self.assertRaises(OSError) as _:
-            Harness(task='ner', model='dslim/bert-base-NER', data=self.data_path, config=self.config_path, hub="huggingface")
+            Harness(task='ner', model='dslim/bert-base-NER', data=self.data_path, config=self.config_path,
+                    hub="huggingface")
 
     def test_attributes(self):
         """
@@ -118,3 +119,26 @@ class HarnessTestCase(unittest.TestCase):
         self.assertEqual(tc_harness._config, loaded_tc_harness._config)
         self.assertEqual(tc_harness.data, loaded_tc_harness.data)
         self.assertNotEqual(tc_harness.model, loaded_tc_harness.model)
+
+    def test_save_load_testcases(self):
+        """"""
+        path_to_file = "/tmp/saved_testcases.pkl"
+        harness = Harness(
+            task='text-classification',
+            model='bert-base-cased',
+            data="tests/fixtures/text_classification.csv",
+            config="tests/fixtures/config_text_classification.yaml",
+            hub="huggingface"
+        )
+        harness.generate()
+        harness.save_testcases(path_to_file)
+
+        new_harness = Harness(
+            task='text-classification',
+            model='bert-base-cased',
+            data="tests/fixtures/text_classification.csv",
+            config="tests/fixtures/config_text_classification.yaml",
+            hub="huggingface"
+        )
+        new_harness.load_testcases(path_to_file)
+        self.assertEqual(harness._testcases, new_harness._testcases)


### PR DESCRIPTION
This PR aims at partially solving #133.

After discussion with David and @luca-martial we temporarilly enable the user to save/load test cases as a pickle file before developping a more user friendly way to manually add/edit tests (see #158)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've added Google style docstrings to my code.
- [x] I've used `pydantic` for typing when/where necessary.
- [x] I have linted my code
- [x] I have added tests to cover my changes.
