### PR TITLE
feature/ Robustness Tests -> Adjective synonym/antonym Swap

### DIFF
--- a/langtest/transform/robustness.py
+++ b/langtest/transform/robustness.py
@@ -17,6 +17,7 @@ from .constants import (
     abbreviation_dict,
     dyslexia_map,
     ocr_typo_dict,
+    adjective_synonym_dict,
 )
 from ..utils.SoundsLikeFunctions import Search
 from ..utils.custom_types import Sample, Span, Transformation
@@ -1361,3 +1362,67 @@ class MultiplePerturbations(BaseRobustness):
                 transformed_list = apply_transformation(sample_list, transformation, prob)
 
         return transformed_list
+
+
+class AdjectiveSynonymSwap(BaseRobustness):
+    """A class for swaping adjectives to their synonyms"""
+
+    alias_name = "adjective_synonym_swap"
+
+    @staticmethod
+    def transform(sample_list: List[Sample], prob: Optional[float] = 1.0) -> List[Sample]:
+        """Converts the input sentences by changing adjectives to their respective synonyms from the adjective synonym dictionary.
+
+        Args:
+            sample_list (List[Sample]): A list of samples to be transformed.
+            prob (Optional[float]): The probability of replacing adjectives words to their respective synonym for each sample.
+                                    Defaults to 1.0, which means all samples will be transformed.
+
+        Returns:
+            List[Sample]: The transformed sample list with adjectives swapped with their respective synonymns.
+        """
+
+        def adjective_synonym_swap(text):
+            transformations = []
+
+            def replace_word(match):
+                original_word = match.group()
+                synonyms = adjective_synonym_dict.get(original_word, [original_word])
+                if synonyms:
+                    transformed_word = random.choice(synonyms)
+                    if transformed_word != original_word and (random.random() < prob):
+                        transformations.append(
+                            Transformation(
+                                original_span=Span(
+                                    start=match.start(),
+                                    end=match.end(),
+                                    word=original_word,
+                                ),
+                                new_span=Span(
+                                    start=match.start(),
+                                    end=match.start() + len(transformed_word),
+                                    word=transformed_word,
+                                ),
+                                ignore=False,
+                            )
+                        )
+                        return transformed_word
+                return original_word
+
+            pattern = r"\b\w+\b"  # Matches whole words using word boundaries
+            transformed_text = re.sub(pattern, replace_word, text)
+
+            return transformed_text, transformations
+
+        for idx, sample in enumerate(sample_list):
+            if isinstance(sample, str):
+                sample_list[idx], _ = adjective_synonym_swap(sample)
+            else:
+                sample.test_case, transformations = adjective_synonym_swap(
+                    sample.original
+                )
+                if sample.task in ("ner", "text-classification"):
+                    sample.transformations = transformations
+                sample.category = "robustness"
+
+        return sample_list

--- a/langtest/transform/robustness.py
+++ b/langtest/transform/robustness.py
@@ -1388,25 +1388,24 @@ class AdjectiveSynonymSwap(BaseRobustness):
             def replace_word(match):
                 original_word = match.group()
                 synonyms = adjective_synonym_dict.get(original_word, [original_word])
-                if synonyms:
-                    transformed_word = random.choice(synonyms)
-                    if transformed_word != original_word and (random.random() < prob):
-                        transformations.append(
-                            Transformation(
-                                original_span=Span(
-                                    start=match.start(),
-                                    end=match.end(),
-                                    word=original_word,
-                                ),
-                                new_span=Span(
-                                    start=match.start(),
-                                    end=match.start() + len(transformed_word),
-                                    word=transformed_word,
-                                ),
-                                ignore=False,
-                            )
+                transformed_word = random.choice(synonyms)
+                if transformed_word != original_word and (random.random() < prob):
+                    transformations.append(
+                        Transformation(
+                            original_span=Span(
+                                start=match.start(),
+                                end=match.end(),
+                                word=original_word,
+                            ),
+                            new_span=Span(
+                                start=match.start(),
+                                end=match.start() + len(transformed_word),
+                                word=transformed_word,
+                            ),
+                            ignore=False,
                         )
-                        return transformed_word
+                    )
+                    return transformed_word
                 return original_word
 
             pattern = r"\b\w+\b"  # Matches whole words using word boundaries

--- a/langtest/transform/robustness.py
+++ b/langtest/transform/robustness.py
@@ -18,6 +18,7 @@ from .constants import (
     dyslexia_map,
     ocr_typo_dict,
     adjective_synonym_dict,
+    adjective_antonym_dict,
 )
 from ..utils.SoundsLikeFunctions import Search
 from ..utils.custom_types import Sample, Span, Transformation
@@ -1379,7 +1380,7 @@ class AdjectiveSynonymSwap(BaseRobustness):
                                     Defaults to 1.0, which means all samples will be transformed.
 
         Returns:
-            List[Sample]: The transformed sample list with adjectives swapped with their respective synonymns.
+            List[Sample]: The transformed sample list with adjectives swapped with their respective synonyms.
         """
 
         def adjective_synonym_swap(text):
@@ -1418,6 +1419,69 @@ class AdjectiveSynonymSwap(BaseRobustness):
                 sample_list[idx], _ = adjective_synonym_swap(sample)
             else:
                 sample.test_case, transformations = adjective_synonym_swap(
+                    sample.original
+                )
+                if sample.task in ("ner", "text-classification"):
+                    sample.transformations = transformations
+                sample.category = "robustness"
+
+        return sample_list
+
+
+class AdjectiveAntonymSwap(BaseRobustness):
+    """A class for swaping adjectives to their antonyms"""
+
+    alias_name = "adjective_antonym_swap"
+
+    @staticmethod
+    def transform(sample_list: List[Sample], prob: Optional[float] = 1.0) -> List[Sample]:
+        """Converts the input sentences by changing adjectives to their respective antonyms from the adjective antonym dictionary.
+
+        Args:
+            sample_list (List[Sample]): A list of samples to be transformed.
+            prob (Optional[float]): The probability of replacing adjectives words to their respective antonyms for each sample.
+                                    Defaults to 1.0, which means all samples will be transformed.
+
+        Returns:
+            List[Sample]: The transformed sample list with adjectives swapped with their respective antonyms.
+        """
+
+        def adjective_antonym_swap(text):
+            transformations = []
+
+            def replace_word(match):
+                original_word = match.group()
+                antonyms = adjective_antonym_dict.get(original_word, [original_word])
+                transformed_word = random.choice(antonyms)
+                if transformed_word != original_word and (random.random() < prob):
+                    transformations.append(
+                        Transformation(
+                            original_span=Span(
+                                start=match.start(),
+                                end=match.end(),
+                                word=original_word,
+                            ),
+                            new_span=Span(
+                                start=match.start(),
+                                end=match.start() + len(transformed_word),
+                                word=transformed_word,
+                            ),
+                            ignore=False,
+                        )
+                    )
+                    return transformed_word
+                return original_word
+
+            pattern = r"\b\w+\b"  # Matches whole words using word boundaries
+            transformed_text = re.sub(pattern, replace_word, text)
+
+            return transformed_text, transformations
+
+        for idx, sample in enumerate(sample_list):
+            if isinstance(sample, str):
+                sample_list[idx], _ = adjective_antonym_swap(sample)
+            else:
+                sample.test_case, transformations = adjective_antonym_swap(
                     sample.original
                 )
                 if sample.task in ("ner", "text-classification"):

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -379,3 +379,13 @@ class RobustnessTestCase(unittest.TestCase):
         self.assertIsInstance(transformed_samples, list)
         for sample in transformed_samples:
             self.assertNotEqual(sample.test_case, sample.original)
+
+    def test_adj_antonym_swap(self) -> None:
+        """
+        Test the AdjectiveSynonymSwap transformation.
+        """
+        transformed_samples = AdjectiveAntonymSwap.transform(self.adj_sentences)
+        print(transformed_samples)
+        self.assertIsInstance(transformed_samples, list)
+        for sample in transformed_samples:
+            self.assertNotEqual(sample.test_case, sample.original)

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -385,7 +385,6 @@ class RobustnessTestCase(unittest.TestCase):
         Test the AdjectiveSynonymSwap transformation.
         """
         transformed_samples = AdjectiveAntonymSwap.transform(self.adj_sentences)
-        print(transformed_samples)
         self.assertIsInstance(transformed_samples, list)
         for sample in transformed_samples:
             self.assertNotEqual(sample.test_case, sample.original)

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -119,6 +119,12 @@ class RobustnessTestCase(unittest.TestCase):
                 original="I can't move to the USA because they have an average of 1000 tornadoes a year, and I'm terrified of them"
             ),
         ]
+        self.adj_sentences = [
+            SequenceClassificationSample(
+                original="Lisa is wearing a beautiful shirt today. This soup is not edible."
+            ),
+            SequenceClassificationSample(original="They have a beautiful house."),
+        ]
         self.test_qa = [
             "20 euro note -- Until now there has been only one complete series of euro notes; however a new series, similar to the current one, is being released. The European Central Bank will, in due time, announce when banknotes from the first series lose legal tender status.",
             "is the first series 20 euro note still legal tender",
@@ -364,3 +370,12 @@ class RobustnessTestCase(unittest.TestCase):
         )
         self.assertIsInstance(transformed_samples, list)
         self.assertNotEqual(original_qa, transformed_samples_qa)
+
+    def test_adj_synonym_swap(self) -> None:
+        """
+        Test the AdjectiveSynonymSwap transformation.
+        """
+        transformed_samples = AdjectiveSynonymSwap.transform(self.adj_sentences)
+        self.assertIsInstance(transformed_samples, list)
+        for sample in transformed_samples:
+            self.assertNotEqual(sample.test_case, sample.original)


### PR DESCRIPTION
# This PR aims at adding new robustness tests ⭐

--------------------------
- <b> CLOSES : #531 </b>
## Checklist:
- [x] Adjective Synonym swap

   - <b> Adjective Synonym swap : Data Dictionary scrapped from this website -> ```https://www.thesaurus.com/```</b>
- [x] Adjective Antonym swap

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've added Google style docstrings to my code.
- [x] I've used `pydantic` for typing when/where necessary.
- [x] I have linted my code
- [x] I have added tests to cover my changes.
