### PR TITLE
Fixed add_contraction bug for QA/Sum

### DIFF
--- a/langtest/transform/robustness.py
+++ b/langtest/transform/robustness.py
@@ -747,7 +747,7 @@ class AddContraction(BaseRobustness):
                     replaced_string = re.sub(
                         contraction,
                         custom_replace,
-                        new_string,
+                        replaced_string,
                         flags=re.IGNORECASE | re.DOTALL,
                     )
 


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I've added Google style docstrings to my code.
- [ ] I've used `pydantic` for typing when/where necessary.
- [ ] I have linted my code
- [ ] I have added tests to cover my changes.
