### PR TITLE
hot-fix(datasource.py)

### DIFF
--- a/langtest/datahandler/datasource.py
+++ b/langtest/datahandler/datasource.py
@@ -323,7 +323,6 @@ class ConllDataset(_IDataset):
                 sentences = doc.strip().split("\n\n")
 
                 if sentences == [""]:
-                    data.append(([""], [""]))
                     continue
 
                 for sent in sentences:


### PR DESCRIPTION
# Description
<!-- Thorougly explain what you are doing and why you are doing it -->
While augmenting the data, wherever sentences are empty it returns a tuple, which causes the error given below.
![image](https://github.com/JohnSnowLabs/langtest/assets/71117423/57c26442-e1a0-48cb-90de-0bd4719c1cc3)

## Usage
<!-- If applicable: show a code snippet or a command on how to use this new addition -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I've added Google style docstrings to my code.
- [ ] I've used `pydantic` for typing when/where necessary.
- [ ] I have linted my code
- [ ] I have added tests to cover my changes.
