### PR TITLE
fix/sentences containing white spaces for ConllDataset

### DIFF
--- a/langtest/datahandler/datasource.py
+++ b/langtest/datahandler/datasource.py
@@ -282,7 +282,7 @@ class ConllDataset(_IDataset):
             ]
             for d_id, doc in enumerate(docs):
                 #  file content to sentence split
-                sentences = re.split(r"\n\n|\n \n|\n\s+\n", doc.strip())
+                sentences = re.split(r"\n\n|\n\s+\n", doc.strip())
 
                 if sentences == [""]:
                     continue
@@ -320,7 +320,7 @@ class ConllDataset(_IDataset):
             ]
             for d_id, doc in enumerate(docs):
                 #  file content to sentence split
-                sentences = re.split(r"\n\n|\n \n|\n\s+\n", doc.strip())
+                sentences = re.split(r"\n\n|\n\s+\n", doc.strip())
 
                 if sentences == [""]:
                     continue

--- a/langtest/datahandler/datasource.py
+++ b/langtest/datahandler/datasource.py
@@ -282,7 +282,7 @@ class ConllDataset(_IDataset):
             ]
             for d_id, doc in enumerate(docs):
                 #  file content to sentence split
-                sentences = doc.strip().split("\n\n")
+                sentences = re.split(r"\n\n|\n \n|\n\s+\n", doc.strip())
 
                 if sentences == [""]:
                     continue
@@ -320,7 +320,7 @@ class ConllDataset(_IDataset):
             ]
             for d_id, doc in enumerate(docs):
                 #  file content to sentence split
-                sentences = doc.strip().split("\n\n")
+                sentences = re.split(r"\n\n|\n \n|\n\s+\n", doc.strip())
 
                 if sentences == [""]:
                     continue


### PR DESCRIPTION
# Description
It is cause by the logic  in load_data and load_raw_data for ConllDataset
```
sentences = doc.strip().split("\n\n")
```
so it is not able to handel condtion where sentence are seprated by 
```
\n   \n
```
we not are doing the splitting of sentences in the right way 

change the condtion to 
```
sentences = re.split(r"\n\n|\n\s+\n", doc.strip())
```

<!-- Thoroughly explain what you are doing and why you are doing it -->

-------------------------------------------------------------------------------------------------
➤ Fixes #680 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Usage
<!-- If applicable: show a code snippet or a command on how to use this new addition -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I've added Google style docstrings to my code.
- [ ] I've used `pydantic` for typing when/where necessary.
- [ ] I have linted my code
- [ ] I have added tests to cover my changes.

## Screenshots (if appropriate):
![image](https://github.com/JohnSnowLabs/langtest/assets/101416953/df45ae5d-d983-438a-9848-e39a98adc0d7)
