### PR TITLE
Ensure uniqueness of sentence duplication

### DIFF
--- a/langtest/augmentation/__init__.py
+++ b/langtest/augmentation/__init__.py
@@ -162,6 +162,8 @@ class AugmentRobustness(BaseAugmentaion):
                         res = TestFactory.transform(
                             self.task, [hash_map[each]], test_type
                         )
+                        if len(res) == 0:
+                            continue
                         hash_map[each] = res[0]
                 else:
                     if test == "swap_entities":

--- a/langtest/transform/__init__.py
+++ b/langtest/transform/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import time
+import logging
 from collections import defaultdict
 from abc import ABC, abstractmethod
 from typing import Dict, List, Union
@@ -512,6 +513,9 @@ class RobustnessTestFactory(ITests):
                             sample.test_type = test_name
                         new_transformed_samples.append(sample)
 
+            if len(transformed_samples) > len(new_transformed_samples):
+                logging.info("Removing samples where no transformation has been applied.")
+
             all_samples.extend(new_transformed_samples)
 
         return all_samples
@@ -709,6 +713,9 @@ class BiasTestFactory(ITests):
                     if sample.original != sample.test_case:
                         sample.test_type = test_name
                         new_transformed_samples.append(sample)
+
+            if len(transformed_samples) > len(new_transformed_samples):
+                logging.info("Removing samples where no transformation has been applied.")
 
             all_samples.extend(new_transformed_samples)
 

--- a/langtest/transform/__init__.py
+++ b/langtest/transform/__init__.py
@@ -501,8 +501,12 @@ class RobustnessTestFactory(ITests):
             new_transformed_samples = []
             if TestFactory.task == "question-answering":
                 for sample in transformed_samples:
-                    if (sample.original_question.replace(" ", "") != sample.perturbed_question.replace(" ", "")) or (
-                        sample.original_context.replace(" ", "") != sample.perturbed_context.replace(" ", "")
+                    if (
+                        sample.original_question.replace(" ", "")
+                        != sample.perturbed_question.replace(" ", "")
+                    ) or (
+                        sample.original_context.replace(" ", "")
+                        != sample.perturbed_context.replace(" ", "")
                     ):
                         if test_name != "multiple_perturbations":
                             sample.test_type = test_name
@@ -514,7 +518,9 @@ class RobustnessTestFactory(ITests):
                             no_transformation_applied_tests.add(test_name)
             else:
                 for sample in transformed_samples:
-                    if sample.original.replace(" ", "") != sample.test_case.replace(" ", ""):
+                    if sample.original.replace(" ", "") != sample.test_case.replace(
+                        " ", ""
+                    ):
                         if test_name != "multiple_perturbations":
                             sample.test_type = test_name
                         new_transformed_samples.append(sample)
@@ -718,8 +724,12 @@ class BiasTestFactory(ITests):
             new_transformed_samples = []
             if TestFactory.task == "question-answering":
                 for sample in transformed_samples:
-                    if (sample.original_question.replace(" ", "") != sample.perturbed_question.replace(" ", "")) or (
-                        sample.original_context.replace(" ", "") != sample.perturbed_context.replace(" ", "")
+                    if (
+                        sample.original_question.replace(" ", "")
+                        != sample.perturbed_question.replace(" ", "")
+                    ) or (
+                        sample.original_context.replace(" ", "")
+                        != sample.perturbed_context.replace(" ", "")
                     ):
                         sample.test_type = test_name
                         new_transformed_samples.append(sample)
@@ -727,7 +737,9 @@ class BiasTestFactory(ITests):
                         no_transformation_applied_tests.add(test_name)
             else:
                 for sample in transformed_samples:
-                    if sample.original.replace(" ", "") != sample.test_case.replace(" ", ""):
+                    if sample.original.replace(" ", "") != sample.test_case.replace(
+                        " ", ""
+                    ):
                         sample.test_type = test_name
                         new_transformed_samples.append(sample)
                     else:

--- a/langtest/transform/__init__.py
+++ b/langtest/transform/__init__.py
@@ -366,8 +366,8 @@ class RobustnessTestFactory(ITests):
                 A list of `Sample` objects representing the resulting dataset after running the robustness test.
         """
         all_samples = []
-        tests_copy = self.tests.copy()  # Create a copy of self.tests
-        no_transformation_applied_tests = []
+        no_transformation_applied_tests = set()
+        tests_copy = self.tests.copy()
         for test_name, params in tests_copy.items():
             if TestFactory.is_augment:
                 data_handler_copy = [x.copy() for x in self._data_handler]
@@ -501,21 +501,28 @@ class RobustnessTestFactory(ITests):
             new_transformed_samples = []
             if TestFactory.task == "question-answering":
                 for sample in transformed_samples:
-                    if (sample.original_question != sample.perturbed_question) or (
-                        sample.original_context != sample.perturbed_context
+                    if (sample.original_question.replace(" ", "") != sample.perturbed_question.replace(" ", "")) or (
+                        sample.original_context.replace(" ", "") != sample.perturbed_context.replace(" ", "")
                     ):
                         if test_name != "multiple_perturbations":
                             sample.test_type = test_name
                         new_transformed_samples.append(sample)
+                    else:
+                        if test_name == "multiple_perturbations":
+                            no_transformation_applied_tests.add(sample.test_type)
+                        else:
+                            no_transformation_applied_tests.add(test_name)
             else:
                 for sample in transformed_samples:
-                    if sample.original != sample.test_case:
+                    if sample.original.replace(" ", "") != sample.test_case.replace(" ", ""):
                         if test_name != "multiple_perturbations":
                             sample.test_type = test_name
                         new_transformed_samples.append(sample)
-
-            if len(transformed_samples) > len(new_transformed_samples):
-                no_transformation_applied_tests.append(test_name)
+                    else:
+                        if test_name == "multiple_perturbations":
+                            no_transformation_applied_tests.add(sample.test_type)
+                        else:
+                            no_transformation_applied_tests.add(test_name)
 
             all_samples.extend(new_transformed_samples)
 
@@ -700,7 +707,7 @@ class BiasTestFactory(ITests):
                 A list of `Sample` objects representing the resulting dataset after running the bias test.
         """
         all_samples = []
-        no_transformation_applied_tests = []
+        no_transformation_applied_tests = set()
         for test_name, params in self.tests.items():
             data_handler_copy = [x.copy() for x in self._data_handler]
 
@@ -711,19 +718,20 @@ class BiasTestFactory(ITests):
             new_transformed_samples = []
             if TestFactory.task == "question-answering":
                 for sample in transformed_samples:
-                    if (sample.original_question != sample.perturbed_question) or (
-                        sample.original_context != sample.perturbed_context
+                    if (sample.original_question.replace(" ", "") != sample.perturbed_question.replace(" ", "")) or (
+                        sample.original_context.replace(" ", "") != sample.perturbed_context.replace(" ", "")
                     ):
                         sample.test_type = test_name
                         new_transformed_samples.append(sample)
+                    else:
+                        no_transformation_applied_tests.add(test_name)
             else:
                 for sample in transformed_samples:
-                    if sample.original != sample.test_case:
+                    if sample.original.replace(" ", "") != sample.test_case.replace(" ", ""):
                         sample.test_type = test_name
                         new_transformed_samples.append(sample)
-
-            if len(transformed_samples) > len(new_transformed_samples):
-                no_transformation_applied_tests.append(test_name)
+                    else:
+                        no_transformation_applied_tests.add(test_name)
 
             all_samples.extend(new_transformed_samples)
 

--- a/langtest/transform/__init__.py
+++ b/langtest/transform/__init__.py
@@ -367,6 +367,7 @@ class RobustnessTestFactory(ITests):
         """
         all_samples = []
         tests_copy = self.tests.copy()  # Create a copy of self.tests
+        no_transformation_applied_tests = []
         for test_name, params in tests_copy.items():
             if TestFactory.is_augment:
                 data_handler_copy = [x.copy() for x in self._data_handler]
@@ -514,9 +515,15 @@ class RobustnessTestFactory(ITests):
                         new_transformed_samples.append(sample)
 
             if len(transformed_samples) > len(new_transformed_samples):
-                logging.info("Removing samples where no transformation has been applied.")
+                no_transformation_applied_tests.append(test_name)
 
             all_samples.extend(new_transformed_samples)
+
+        if no_transformation_applied_tests:
+            logging.warning(
+                "Removing samples where no transformation has been applied in the following tests: "
+                + ", ".join(no_transformation_applied_tests)
+            )
 
         return all_samples
 
@@ -693,6 +700,7 @@ class BiasTestFactory(ITests):
                 A list of `Sample` objects representing the resulting dataset after running the bias test.
         """
         all_samples = []
+        no_transformation_applied_tests = []
         for test_name, params in self.tests.items():
             data_handler_copy = [x.copy() for x in self._data_handler]
 
@@ -715,9 +723,15 @@ class BiasTestFactory(ITests):
                         new_transformed_samples.append(sample)
 
             if len(transformed_samples) > len(new_transformed_samples):
-                logging.info("Removing samples where no transformation has been applied.")
+                no_transformation_applied_tests.append(test_name)
 
             all_samples.extend(new_transformed_samples)
+
+        if no_transformation_applied_tests:
+            logging.warning(
+                "Removing samples where no transformation has been applied in the following tests: "
+                + ", ".join(no_transformation_applied_tests)
+            )
 
         return all_samples
 

--- a/langtest/transform/__init__.py
+++ b/langtest/transform/__init__.py
@@ -496,10 +496,24 @@ class RobustnessTestFactory(ITests):
                     prob=params.pop("prob", 1.0),
                 )
 
-            for sample in transformed_samples:
-                if test_name != "multiple_perturbations":
-                    sample.test_type = test_name
-            all_samples.extend(transformed_samples)
+            new_transformed_samples = []
+            if TestFactory.task == "question-answering":
+                for sample in transformed_samples:
+                    if (sample.original_question != sample.perturbed_question) or (
+                        sample.original_context != sample.perturbed_context
+                    ):
+                        if test_name != "multiple_perturbations":
+                            sample.test_type = test_name
+                        new_transformed_samples.append(sample)
+            else:
+                for sample in transformed_samples:
+                    if sample.original != sample.test_case:
+                        if test_name != "multiple_perturbations":
+                            sample.test_type = test_name
+                        new_transformed_samples.append(sample)
+
+            all_samples.extend(new_transformed_samples)
+
         return all_samples
 
     @staticmethod
@@ -682,9 +696,21 @@ class BiasTestFactory(ITests):
                 data_handler_copy, **params.get("parameters", {})
             )
 
-            for sample in transformed_samples:
-                sample.test_type = test_name
-            all_samples.extend(transformed_samples)
+            new_transformed_samples = []
+            if TestFactory.task == "question-answering":
+                for sample in transformed_samples:
+                    if (sample.original_question != sample.perturbed_question) or (
+                        sample.original_context != sample.perturbed_context
+                    ):
+                        sample.test_type = test_name
+                        new_transformed_samples.append(sample)
+            else:
+                for sample in transformed_samples:
+                    if sample.original != sample.test_case:
+                        sample.test_type = test_name
+                        new_transformed_samples.append(sample)
+
+            all_samples.extend(new_transformed_samples)
 
         return all_samples
 

--- a/langtest/transform/utils.py
+++ b/langtest/transform/utils.py
@@ -353,7 +353,20 @@ def check_name(word: str, name_lists: List[List[str]]) -> bool:
     )
 
 
-def filter_unique_samples(task, transformed_samples, test_name):
+def filter_unique_samples(task: str, transformed_samples: list, test_name: str):
+    """
+    Filter and remove samples with no applied transformations from the list of transformed_samples.
+
+    Args:
+        task (str): The type of task.
+        transformed_samples (list): List of transformed samples to be filtered.
+        test_name (str): Name of the test.
+
+    Returns:
+        new_transformed_samples (list): List of filtered samples with unique transformations.
+        no_transformation_applied_tests (set): Set of test names for which no transformation
+            was applied due to non-uniqueness.
+    """
     no_transformation_applied_tests = set()
     new_transformed_samples = []
     if task == "question-answering":

--- a/langtest/transform/utils.py
+++ b/langtest/transform/utils.py
@@ -351,3 +351,38 @@ def check_name(word: str, name_lists: List[List[str]]) -> bool:
     return any(
         word.lower() in [name.lower() for name in name_list] for name_list in name_lists
     )
+
+
+def filter_unique_samples(task, transformed_samples, test_name):
+    no_transformation_applied_tests = set()
+    new_transformed_samples = []
+    if task == "question-answering":
+        for sample in transformed_samples:
+            if (
+                sample.original_question.replace(" ", "")
+                != sample.perturbed_question.replace(" ", "")
+            ) or (
+                sample.original_context.replace(" ", "")
+                != sample.perturbed_context.replace(" ", "")
+            ):
+                if test_name != "multiple_perturbations":
+                    sample.test_type = test_name
+                new_transformed_samples.append(sample)
+            else:
+                if test_name == "multiple_perturbations":
+                    no_transformation_applied_tests.add(sample.test_type)
+                else:
+                    no_transformation_applied_tests.add(test_name)
+    else:
+        for sample in transformed_samples:
+            if sample.original.replace(" ", "") != sample.test_case.replace(" ", ""):
+                if test_name != "multiple_perturbations":
+                    sample.test_type = test_name
+                new_transformed_samples.append(sample)
+            else:
+                if test_name == "multiple_perturbations":
+                    no_transformation_applied_tests.add(sample.test_type)
+                else:
+                    no_transformation_applied_tests.add(test_name)
+
+    return new_transformed_samples, no_transformation_applied_tests

--- a/tests/test_augmentation.py
+++ b/tests/test_augmentation.py
@@ -180,7 +180,7 @@ class AugmentWorkflowTestCase(unittest.TestCase):
         harness.data = harness.data[:50]
         report = harness.generate().run().report()
         self.assertIsInstance(report, pd.DataFrame)
-        custom_proportions = {"uppercase": 0.8, "lowercase": 0.8}
+        custom_proportions = {"uppercase": 0.8, "add_ocr_typo": 0.8}
         harness.augment(
             training_data={"data_source": "tests/fixtures/text_classification.csv"},
             save_data_path="tests/fixtures/augmented_text_classification.csv",

--- a/tests/test_augmentation.py
+++ b/tests/test_augmentation.py
@@ -180,7 +180,7 @@ class AugmentWorkflowTestCase(unittest.TestCase):
         harness.data = harness.data[:50]
         report = harness.generate().run().report()
         self.assertIsInstance(report, pd.DataFrame)
-        custom_proportions = {"uppercase": 0.8, "add_ocr_typo": 0.8}
+        custom_proportions = {"uppercase": 0.8}
         harness.augment(
             training_data={"data_source": "tests/fixtures/text_classification.csv"},
             save_data_path="tests/fixtures/augmented_text_classification.csv",

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -268,6 +268,22 @@ class HarnessTestCase(unittest.TestCase):
         self.assertEqual(tc_harness.data, loaded_tc_harness.data)
         self.assertNotEqual(tc_harness.model, loaded_tc_harness.model)
 
+    def test_filtering_Out_Same_Original_And_TestCase(self):
+        """
+        Test filtering out records where 'original' and 'test_case' are the same for text classification task.
+        """
+        save_dir = "/tmp/saved_text_classification_harness_test"
+        tc_harness = Harness(
+            task="text-classification",
+            model={"model": "bert-base-cased", "hub": "huggingface"},
+            data={"data_source": "tests/fixtures/text_classification.csv"},
+            config="tests/fixtures/config_text_classification.yaml",
+        )
+        tc_harness.generate()
+        df = tc_harness.testcases()
+        filtered_df = df[df["original"] == df["test_case"]]
+        self.assertTrue(filtered_df.empty)
+
 
 class DefaultCodeBlocksTestCase(unittest.TestCase):
     """


### PR DESCRIPTION
# Description
This PR focuses on refining testcase generation for robustness and bias categories .The goal is to filter out records where original and transformed samples are identical from the generated testcases.

-------------------------------------------------------------------------------------------------
- Fixes #569 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I've added Google style docstrings to my code.
- [ ] I've used `pydantic` for typing when/where necessary.
- [x] I have linted my code
- [x] I have added tests to cover my changes.
