### PR TITLE
Bug/augmentation output differs from input file

### DIFF
--- a/langtest/augmentation/__init__.py
+++ b/langtest/augmentation/__init__.py
@@ -437,6 +437,10 @@ class TemplaticAugment(BaseAugmentaion):
                     )
                     for result in template.expected_results.predictions[cursor:]:
                         if prediction[0].entity.endswith(result.entity):
+                            for each_prediction in prediction:
+                                if isinstance(each_prediction, NERPrediction):
+                                    each_prediction.chunk_tag = "-X-"
+                                    each_prediction.pos_tag = "-X-"
                             other_predictions.extend(prediction)
                             cursor += 1
                             break

--- a/langtest/datahandler/datasource.py
+++ b/langtest/datahandler/datasource.py
@@ -407,8 +407,9 @@ class ConllDataset(_IDataset):
                 path to save the data to
         """
         otext = ""
+        temp_id = None
         for i in data:
-            text = Formatter.process(i, output_format="conll")
+            text, temp_id = Formatter.process(i, output_format="conll", temp_id=temp_id)
             otext += text + "\n"
 
         with open(output_path, "wb") as fwriter:

--- a/langtest/transform/robustness.py
+++ b/langtest/transform/robustness.py
@@ -487,12 +487,16 @@ class SwapEntities(BaseRobustness):
                 sample.category = "robustness"
                 if all([label == "O" for label in sample_labels]):
                     sample.test_case = sample.original
-                    continue
+                    break
 
                 sent_tokens = sample.original.split(" ")
 
                 ent_start_pos = [1 if label[0] == "B" else 0 for label in sample_labels]
                 ent_idx = [i for i, value in enumerate(ent_start_pos) if value == 1]
+                
+                if not ent_idx:
+                    sample.test_case = sample.original
+                    break
 
                 replace_idx = random.choice(ent_idx)
                 ent_type = sample_labels[replace_idx][2:]

--- a/langtest/transform/robustness.py
+++ b/langtest/transform/robustness.py
@@ -493,7 +493,7 @@ class SwapEntities(BaseRobustness):
 
                 ent_start_pos = [1 if label[0] == "B" else 0 for label in sample_labels]
                 ent_idx = [i for i, value in enumerate(ent_start_pos) if value == 1]
-                
+
                 if not ent_idx:
                     sample.test_case = sample.original
                     break

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -31,7 +31,10 @@ class TestNERDataset:
         test_type="add_context",
         expected_results=NEROutput(
             predictions=[
-                NERPrediction(entity="PROD", span=Span(start=10, end=13, word="KFC"))
+                NERPrediction(entity="O", span=Span(start=10, end=13, word="I")),
+                NERPrediction(entity="O", span=Span(start=10, end=13, word="do")),
+                NERPrediction(entity="O", span=Span(start=10, end=13, word="love")),
+                NERPrediction(entity="PROD", span=Span(start=10, end=13, word="KFC")),
             ]
         ),
     )


### PR DESCRIPTION
# Description
This PR fixes augmentation and also for swap_entities ( takes care of sentences having I-labels only without the B-tag)

We fixed an issue in the data augmentation process where augmented files format differed from input files, leading to inconsistencies that was negatively impacting model training and evaluation. 

**Expected Output**
```
-DOCSTART- -X- -X- O

CRICKET NNP B-NP O
- : O O
LEICESTERSHIRE NNP B-NP B-ORG
TAKE NNP I-NP O
OVER IN B-PP O
AT NNP B-NP O
TOP NNP I-NP O
AFTER NNP I-NP O
INNINGS NNP I-NP O
VICTORY NN I-NP O
. . O O
```
**Actual Output**
```
-DOCSTART- -X- -X- O

CRICKET -X- -X- O
- -X- -X- O
LEICESTERSHIRE -X- -X- B-ORG
TAKE -X- -X- O
OVER -X- -X- O
AT -X- -X- O
TOP -X- -X- O
AFTER -X- -X-O
INNINGS -X- -X- O
VICTORY -X- -X- O
. -X- -X- O
```

Swap-entities issue:
![image](https://github.com/JohnSnowLabs/langtest/assets/71844877/24326e25-f7ec-4457-a87c-678e1888b236)
