### PR TITLE
fix :langchain for text classification task 

### DIFF
--- a/langtest/modelhandler/transformers_modelhandler.py
+++ b/langtest/modelhandler/transformers_modelhandler.py
@@ -345,15 +345,6 @@ class PretrainedModelForQA(_ModelHandler):
         model (transformers.pipeline.Pipeline): Pretrained HuggingFace QA pipeline for predictions.
     """
 
-    LIB_NAME = "langchain"
-    if try_import_lib(LIB_NAME):
-        langchain = importlib.import_module(LIB_NAME)
-        PromptTemplate = getattr(langchain, "PromptTemplate")
-    else:
-        raise ModuleNotFoundError(
-            f"The '{LIB_NAME}' package is not installed. Please install it using 'pip install {LIB_NAME}'."
-        )
-
     def __init__(self, hub, model, **kwargs):
         """Constructor method
 
@@ -365,6 +356,16 @@ class PretrainedModelForQA(_ModelHandler):
             f"Pipeline should be '{Pipeline}', passed model is: '{type(model)}'"
         )
         self.model = model
+
+    def _check_langchain_package(self):
+        LIB_NAME = "langchain"
+        if try_import_lib(LIB_NAME):
+            langchain = importlib.import_module(LIB_NAME)
+            PromptTemplate = getattr(langchain, "PromptTemplate")
+        else:
+            raise ModuleNotFoundError(
+                f"The '{LIB_NAME}' package is not installed. Please install it using 'pip install {LIB_NAME}'."
+            )
 
     @staticmethod
     def load_model(hub: str, path: str, **kwargs) -> "Pipeline":

--- a/langtest/modelhandler/transformers_modelhandler.py
+++ b/langtest/modelhandler/transformers_modelhandler.py
@@ -361,7 +361,7 @@ class PretrainedModelForQA(_ModelHandler):
         LIB_NAME = "langchain"
         if try_import_lib(LIB_NAME):
             langchain = importlib.import_module(LIB_NAME)
-            PromptTemplate = getattr(langchain, "PromptTemplate")
+            self.PromptTemplate = getattr(langchain, "PromptTemplate")
         else:
             raise ModuleNotFoundError(
                 f"The '{LIB_NAME}' package is not installed. Please install it using 'pip install {LIB_NAME}'."

--- a/langtest/modelhandler/transformers_modelhandler.py
+++ b/langtest/modelhandler/transformers_modelhandler.py
@@ -10,8 +10,8 @@ from ..utils.custom_types import (
     SequenceClassificationOutput,
     TranslationOutput,
 )
-
-from langchain import PromptTemplate
+from langtest.utils.lib_manager import try_import_lib
+import importlib
 
 
 class PretrainedModelForNER(_ModelHandler):
@@ -345,6 +345,15 @@ class PretrainedModelForQA(_ModelHandler):
         model (transformers.pipeline.Pipeline): Pretrained HuggingFace QA pipeline for predictions.
     """
 
+    LIB_NAME = "langchain"
+    if try_import_lib(LIB_NAME):
+        langchain = importlib.import_module(LIB_NAME)
+        PromptTemplate = getattr(langchain, "PromptTemplate")
+    else:
+        raise ModuleNotFoundError(
+            f"The '{LIB_NAME}' package is not installed. Please install it using 'pip install {LIB_NAME}'."
+        )
+
     def __init__(self, hub, model, **kwargs):
         """Constructor method
 
@@ -383,7 +392,7 @@ class PretrainedModelForQA(_ModelHandler):
         Returns:
             str: Output model for QA tasks
         """
-        prompt_template = PromptTemplate(**prompt)
+        prompt_template = self.PromptTemplate(**prompt)
         p = prompt_template.format(**text)
         prediction = self.model(p, **kwargs)
         return prediction[0]["generated_text"][len(p) :]


### PR DESCRIPTION
# Description

For text classification task and hub - huggingface , we have don't need to install langchain. This bug is due to the import statement in In the transformers_modelhandler.py 

![image](https://github.com/JohnSnowLabs/langtest/assets/101416953/fd818533-4337-4a64-9ed5-c0db67908614)
-------------------------------------------------------------------------------------------------
- fix: #741 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I've added Google style docstrings to my code.
- [ ] I've used `pydantic` for typing when/where necessary.
- [ ] I have linted my code
- [ ] I have added tests to cover my changes.

## Usage
```
from langtest import Harness
harness = Harness(
            task = "text-classification",
            model={"model":'lvwerra/distilbert-imdb', "hub":"huggingface"},

        )
```
## Screenshots (if appropriate):

![image](https://github.com/JohnSnowLabs/langtest/assets/101416953/653452f6-7438-40ea-94cd-1b4518b4ec65)
