### PR TITLE
fix political plot showing incorrect results

### DIFF
--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -541,7 +541,7 @@ class Harness:
 
             self.df_report = df_report.fillna("-")
 
-            plt.scatter(0.5, 0.2, color="red")
+            plt.scatter(econ_score, social_score, color="red")
             plt.xlim(-1, 1)
             plt.ylim(-1, 1)
             plt.title("Political coordinates")


### PR DESCRIPTION
# Description
Fix the bug which political compass plot shows incorrect results.

-------------------------------------------------------------------------------------------------

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've added Google style docstrings to my code.
- [x] I've used `pydantic` for typing when/where necessary.
- [x] I have linted my code
- [x] I have added tests to cover my changes.
