### PR TITLE
Add simpler LLM evaluation for some datasets.

### DIFF
--- a/langtest/utils/custom_types/sample.py
+++ b/langtest/utils/custom_types/sample.py
@@ -495,6 +495,9 @@ class QASample(BaseQASample):
         from ...transform.constants import qa_prompt_template
         from langchain.prompts import PromptTemplate
 
+        if self.dataset_name in ["BoolQ"] and (self.actual_results == self.expected_results):
+            return True
+
         if "llm" in str(type(llm_model.model_class)):
             if self.dataset_name not in ["BoolQ", "TruthfulQA", "Quac", "BBQ"]:
                 PROMPT = PromptTemplate(

--- a/langtest/utils/custom_types/sample.py
+++ b/langtest/utils/custom_types/sample.py
@@ -501,7 +501,7 @@ class QASample(BaseQASample):
             "LogiQA",
             "MMLU",
             "OpenBookQA",
-        ] and (self.actual_results == self.expected_results):
+        ] and (self.actual_results.lower() == self.expected_results.lower()):
             return True
 
         if "llm" in str(type(llm_model.model_class)):

--- a/langtest/utils/custom_types/sample.py
+++ b/langtest/utils/custom_types/sample.py
@@ -495,7 +495,13 @@ class QASample(BaseQASample):
         from ...transform.constants import qa_prompt_template
         from langchain.prompts import PromptTemplate
 
-        if self.dataset_name in ["BoolQ"] and (self.actual_results == self.expected_results):
+        if self.dataset_name in [
+            "BoolQ",
+            "asdiv",
+            "LogiQA",
+            "MMLU",
+            "OpenBookQA",
+        ] and (self.actual_results == self.expected_results):
             return True
 
         if "llm" in str(type(llm_model.model_class)):


### PR DESCRIPTION
# Description
Improve evaluation of LLM models for some datasets. This PR allows direct comparison on some datasets like BoolQ which has distinct and strict answers to be evaluated using direct comparison rather than self-evaluation.

-------------------------------------------------------------------------------------------------

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Usage
This PR improves performance in the backend.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've added Google style docstrings to my code.
- [x] I've used `pydantic` for typing when/where necessary.
- [x] I have linted my code
- [x] I have added tests to cover my changes.
