### PR TITLE
fix hardcoded task in huggingface datasets

### DIFF
--- a/langtest/datahandler/datasource.py
+++ b/langtest/datahandler/datasource.py
@@ -1658,7 +1658,7 @@ class HuggingFaceDataset(_IDataset):
             rows.append(row)
 
         df = pd.DataFrame(
-            rows, columns=list(self.COLUMN_NAMES["text-classification"].keys())
+            rows, columns=list(self.COLUMN_NAMES[self.task].keys())
         )
         df.to_csv(output_path, index=False, encoding="utf-8")
 

--- a/langtest/datahandler/datasource.py
+++ b/langtest/datahandler/datasource.py
@@ -1657,9 +1657,7 @@ class HuggingFaceDataset(_IDataset):
             row = Formatter.process(s, output_format="csv")
             rows.append(row)
 
-        df = pd.DataFrame(
-            rows, columns=list(self.COLUMN_NAMES[self.task].keys())
-        )
+        df = pd.DataFrame(rows, columns=list(self.COLUMN_NAMES[self.task].keys()))
         df.to_csv(output_path, index=False, encoding="utf-8")
 
     def _row_to_sample_classification(self, data_row: Dict[str, str]) -> Sample:


### PR DESCRIPTION
# Description
There is an hardcoded 'text-classification' task in the HF datahandler that prevents other tasks to be used for augmentation.

-------------------------------------------------------------------------------------------------

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've added Google style docstrings to my code.
- [x] I've used `pydantic` for typing when/where necessary.
- [x] I have linted my code
- [x] I have added tests to cover my changes.