### PR TITLE
Model Selection Option and  Save harness.run() Results

### DIFF
--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -12,7 +12,6 @@ import yaml
 
 
 from pkg_resources import resource_filename
-from langtest.modelhandler import ModelAPI
 
 from .tasks import TaskManager
 from .augmentation import AugmentRobustness, TemplaticAugment
@@ -844,8 +843,9 @@ class Harness:
                 path to folder containing all the needed files to load an saved `Harness`
             task (str):
                 task for which the model is to be evaluated.
-            model (str | ModelAPI):
-                ModelAPI object or path to the model to be evaluated.
+            model (Union[list, dict], optional): Specifies the model to be evaluated.
+                If provided as a list, each element should be a dictionary with 'model' and 'hub' keys.
+                If provided as a dictionary, it must contain 'model' and 'hub' keys when specifying a path.
             hub (str, optional):
                 model hub to load from the path. Required if path is passed as 'model'.
 

--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -303,17 +303,8 @@ class Harness:
                 self._config = yaml.safe_load(yml)
         self._config_copy = self._config
 
-        global HARNESS_CONFIG, EVAL_MODEL
+        global HARNESS_CONFIG
         HARNESS_CONFIG = self._config
-
-        if "evaluation" in self._config and "metric" in self._config["evaluation"]:
-            if self._config["evaluation"]["metric"] == "QAEvalChain":
-                model = self._config["evaluation"].get("model", None)
-                hub = self._config["evaluation"].get("hub", None)
-                if model and hub:
-                    EVAL_MODEL = self.task.model(
-                        model, hub, **self._config.get("model_parameters", {})
-                    )
 
         return self._config
 

--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -281,7 +281,6 @@ class Harness:
         self.default_min_pass_dict = None
         self.df_report = None
 
-
     def __repr__(self) -> str:
         return ""
 
@@ -817,8 +816,8 @@ class Harness:
 
         if not os.path.isdir(save_dir):
             os.mkdir(save_dir)
-        
-        if include_generated_results and self._generated_results  :
+
+        if include_generated_results and self._generated_results:
             with open(os.path.join(save_dir, "generated_results.pkl"), "wb") as writer:
                 pickle.dump(self._generated_results, writer)
 

--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -281,6 +281,7 @@ class Harness:
         self.default_min_pass_dict = None
         self.df_report = None
 
+
     def __repr__(self) -> str:
         return ""
 
@@ -544,6 +545,7 @@ class Harness:
         Returns:
             pd.DataFrame: Generated dataframe.
         """
+
         if self._generated_results is None:
             logging.warning(Warnings.W000)
             return
@@ -815,6 +817,10 @@ class Harness:
 
         if not os.path.isdir(save_dir):
             os.mkdir(save_dir)
+        
+        if include_generated_results and self._generated_results  :
+            with open(os.path.join(save_dir, "generated_results.pkl"), "wb") as writer:
+                pickle.dump(self._generated_results, writer)
 
         with open(os.path.join(save_dir, "config.yaml"), "w", encoding="utf-8") as yml:
             yml.write(yaml.safe_dump(self._config_copy))
@@ -829,9 +835,8 @@ class Harness:
     def load(
         cls,
         save_dir: str,
-        model: Union[str, "ModelAPI"],
         task: str,
-        hub: Optional[str] = None,
+        model: Optional[Union[list, dict]] = None,
     ) -> "Harness":
         """Loads a previously saved `Harness` from a given configuration and dataset
 
@@ -858,12 +863,15 @@ class Harness:
 
         harness = Harness(
             task=task,
-            model={"model": model, "hub": hub},
+            model=model,
             data={"data_source": data},
             config=os.path.join(save_dir, "config.yaml"),
         )
         harness.generate()
-
+        if os.path.exists(os.path.join(save_dir, "generated_results.pkl")):
+            with open(os.path.join(save_dir, "generated_results.pkl"), "rb") as reader:
+                generated_results = pickle.load(reader)
+            harness._generated_results = generated_results
         return harness
 
     def edit_testcases(self, output_path: str, **kwargs):

--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -24,7 +24,7 @@ from .transform.utils import RepresentationOperation
 from langtest.utils.lib_manager import try_import_lib
 from .errors import Warnings, Errors
 
-GLOBAL_MODEL = None
+EVAL_MODEL = None
 GLOBAL_HUB = None
 HARNESS_CONFIG = None
 
@@ -268,9 +268,9 @@ class Harness:
         formatted_config = json.dumps(self._config, indent=1)
         print("Test Configuration : \n", formatted_config)
 
-        global GLOBAL_MODEL, GLOBAL_HUB
+        global EVAL_MODEL, GLOBAL_HUB
         if not isinstance(model, list):
-            GLOBAL_MODEL = self.model
+            EVAL_MODEL = self.model
             GLOBAL_HUB = hub
 
         self._testcases = None
@@ -303,7 +303,7 @@ class Harness:
                 self._config = yaml.safe_load(yml)
         self._config_copy = self._config
 
-        global HARNESS_CONFIG, GLOBAL_MODEL
+        global HARNESS_CONFIG, EVAL_MODEL
         HARNESS_CONFIG = self._config
 
         if "evaluation" in self._config and "metric" in self._config["evaluation"]:
@@ -311,7 +311,7 @@ class Harness:
                 model = self._config["evaluation"].get("model", None)
                 hub = self._config["evaluation"].get("hub", None)
                 if model and hub:
-                    GLOBAL_MODEL = self.task.model(
+                    EVAL_MODEL = self.task.model(
                         model, hub, **self._config.get("model_parameters", {})
                     )
 

--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -304,8 +304,17 @@ class Harness:
                 self._config = yaml.safe_load(yml)
         self._config_copy = self._config
 
-        global HARNESS_CONFIG
+        global HARNESS_CONFIG, GLOBAL_MODEL
         HARNESS_CONFIG = self._config
+
+        if "evaluation" in self._config and "metric" in self._config["evaluation"]:
+            if self._config["evaluation"]["metric"] == "QAEvalChain":
+                model = self._config["evaluation"].get("model", None)
+                hub = self._config["evaluation"].get("hub", None)
+                if model and hub:
+                    GLOBAL_MODEL = self.task.model(
+                        model, hub, **self._config.get("model_parameters", {})
+                    )
 
         return self._config
 
@@ -790,7 +799,7 @@ class Harness:
 
         return testcases_df.fillna("-")
 
-    def save(self, save_dir: str) -> None:
+    def save(self, save_dir: str, include_generated_results: bool = False) -> None:
         """Save the configuration, generated testcases and the `DataFactory` to be reused later.
 
         Args:

--- a/langtest/utils/custom_types/sample.py
+++ b/langtest/utils/custom_types/sample.py
@@ -601,7 +601,11 @@ class QASample(BaseQASample):
             bool: True if the sample passed the evaluation, False otherwise.
         """
         self.__update_params()
-        if "evaluation" in self.config and "metric" in self.config["evaluation"] and self.config["evaluation"]["metric"]!="QAEvalChain":
+        if (
+            "evaluation" in self.config
+            and "metric" in self.config["evaluation"]
+            and self.config["evaluation"]["metric"] != "QAEvalChain"
+        ):
             result = getattr(self, f'is_pass_{self.config.get("evaluation")["metric"]}')()
             return result
 
@@ -610,6 +614,7 @@ class QASample(BaseQASample):
             from langchain.evaluation.qa import QAEvalChain
             from ...transform.constants import qa_prompt_template
             from langchain.prompts import PromptTemplate
+
             print(llm_model.model)
 
             if self.dataset_name in [

--- a/langtest/utils/custom_types/sample.py
+++ b/langtest/utils/custom_types/sample.py
@@ -379,7 +379,7 @@ class BaseQASample(BaseModel):
     config: str = None
     distance_result: float = None
     eval_model: str = None
-    __is_pass: bool = None
+    ran_pass: bool = None
 
     def __init__(self, **data):
         """Constructor method"""
@@ -618,8 +618,9 @@ class QASample(BaseQASample):
         Returns:
             bool: True if the sample passed the evaluation, False otherwise.
         """
-        if self.__is_pass:
-            return self.__is_pass
+     
+        if self.ran_pass:
+            return self.ran_pass
         else:
             self.__update_params()
             if (
@@ -628,7 +629,7 @@ class QASample(BaseQASample):
                 and self.config["evaluation"]["metric"] != "QAEvalChain"
             ):
                 result = getattr(self, f'is_pass_{self.config.get("evaluation")["metric"]}')()
-                self.__is_pass = result
+                self.ran_pass = result
                 return result
 
             else:
@@ -652,7 +653,7 @@ class QASample(BaseQASample):
                     self.actual_results.lower().strip()
                     == self.expected_results.lower().strip()
                 ):
-                    self.__is_pass = True
+                    self.ran_pass = True
                     return True
 
                 if "llm" in str(type(self.eval_model)):
@@ -714,7 +715,7 @@ class QASample(BaseQASample):
                         list(graded_outputs[0].values())[0].replace("\n", "").strip()
                         == "CORRECT"
                     )
-                    self.__is_pass = result
+                    self.ran_pass = result
                     return result
                 else:
                     prediction = self.eval_model(
@@ -729,7 +730,7 @@ class QASample(BaseQASample):
                         },
                     )
                     result = prediction == "CORRECT"
-                    self.__is_pass = result
+                    self.ran_pass = result
                     return result
 
 

--- a/langtest/utils/custom_types/sample.py
+++ b/langtest/utils/custom_types/sample.py
@@ -610,7 +610,7 @@ class QASample(BaseQASample):
             return result
 
         else:
-            from ...langtest import GLOBAL_MODEL as llm_model
+            from ...langtest import EVAL_MODEL as llm_model
             from langchain.evaluation.qa import QAEvalChain
             from ...transform.constants import qa_prompt_template
             from langchain.prompts import PromptTemplate
@@ -2349,7 +2349,7 @@ class SycophancySample(BaseModel):
         Returns:
             bool: True if the prompt evaluation passes, False otherwise.
         """
-        from ...langtest import GLOBAL_MODEL as llm_model
+        from ...langtest import EVAL_MODEL as llm_model
         from langchain.evaluation.qa import QAEvalChain
         from ...transform.constants import qa_prompt_template
         from langchain.prompts import PromptTemplate

--- a/langtest/utils/custom_types/sample.py
+++ b/langtest/utils/custom_types/sample.py
@@ -618,8 +618,9 @@ class QASample(BaseQASample):
         Returns:
             bool: True if the sample passed the evaluation, False otherwise.
         """
-     
+
         if self.ran_pass:
+            print("Already Ran")
             return self.ran_pass
         else:
             self.__update_params()
@@ -628,7 +629,9 @@ class QASample(BaseQASample):
                 and "metric" in self.config["evaluation"]
                 and self.config["evaluation"]["metric"] != "QAEvalChain"
             ):
-                result = getattr(self, f'is_pass_{self.config.get("evaluation")["metric"]}')()
+                result = getattr(
+                    self, f'is_pass_{self.config.get("evaluation")["metric"]}'
+                )()
                 self.ran_pass = result
                 return result
 
@@ -683,7 +686,10 @@ class QASample(BaseQASample):
                         ]
 
                         predictions = [
-                            {"question": self.perturbed_question, "text": self.actual_results}
+                            {
+                                "question": self.perturbed_question,
+                                "text": self.actual_results,
+                            }
                         ]
 
                         graded_outputs = eval_chain.evaluate(

--- a/langtest/utils/custom_types/sample.py
+++ b/langtest/utils/custom_types/sample.py
@@ -496,7 +496,8 @@ class QASample(BaseQASample):
                 }
             )
             if "evaluation" in self.config and "metric" in self.config["evaluation"]:
-                result.update({"eval_score": self.distance_result})
+                if self.config["evaluation"]["metric"] != "QAEvalChain":
+                    result.update({"eval_score": self.distance_result})
 
         return result
 

--- a/langtest/utils/custom_types/sample.py
+++ b/langtest/utils/custom_types/sample.py
@@ -601,7 +601,7 @@ class QASample(BaseQASample):
             bool: True if the sample passed the evaluation, False otherwise.
         """
         self.__update_params()
-        if "evaluation" in self.config and "metric" in self.config["evaluation"]:
+        if "evaluation" in self.config and "metric" in self.config["evaluation"] and self.config["evaluation"]["metric"]!="QAEvalChain":
             result = getattr(self, f'is_pass_{self.config.get("evaluation")["metric"]}')()
             return result
 
@@ -610,6 +610,7 @@ class QASample(BaseQASample):
             from langchain.evaluation.qa import QAEvalChain
             from ...transform.constants import qa_prompt_template
             from langchain.prompts import PromptTemplate
+            print(llm_model.model)
 
             if self.dataset_name in [
                 "BoolQ",

--- a/langtest/utils/custom_types/sample.py
+++ b/langtest/utils/custom_types/sample.py
@@ -615,8 +615,6 @@ class QASample(BaseQASample):
             from ...transform.constants import qa_prompt_template
             from langchain.prompts import PromptTemplate
 
-            print(llm_model.model)
-
             if self.dataset_name in [
                 "BoolQ",
                 "asdiv",

--- a/langtest/utils/custom_types/sample.py
+++ b/langtest/utils/custom_types/sample.py
@@ -620,7 +620,6 @@ class QASample(BaseQASample):
         """
 
         if self.ran_pass:
-            print("Already Ran")
             return self.ran_pass
         else:
             self.__update_params()

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -131,7 +131,9 @@ class HarnessTestCase(unittest.TestCase):
         self.harness.save(save_dir)
 
         loaded_harness = Harness.load(
-            save_dir=save_dir, task="ner", model={"model":"bert-base-cased", "hub":"huggingface"}
+            save_dir=save_dir,
+            task="ner",
+            model={"model": "bert-base-cased", "hub": "huggingface"},
         )
         self.assertEqual(self.harness._config, loaded_harness._config)
         self.assertEqual(self.harness.data, loaded_harness.data)
@@ -154,7 +156,7 @@ class HarnessTestCase(unittest.TestCase):
         loaded_tc_harness = Harness.load(
             save_dir=save_dir,
             task="text-classification",
-            model={"model": "bert-base-cased", "hub": "huggingface"}
+            model={"model": "bert-base-cased", "hub": "huggingface"},
         )
         self.assertEqual(tc_harness._config, loaded_tc_harness._config)
         self.assertEqual(tc_harness.data, loaded_tc_harness.data)
@@ -177,7 +179,7 @@ class HarnessTestCase(unittest.TestCase):
         loaded_tc_harness = Harness.load(
             save_dir=save_dir,
             task="text-classification",
-            model={"model": "aychang/roberta-base-imdb", "hub": "huggingface"}
+            model={"model": "aychang/roberta-base-imdb", "hub": "huggingface"},
         )
         self.assertEqual(tc_harness._config, loaded_tc_harness._config)
         self.assertEqual(tc_harness.data, loaded_tc_harness.data)
@@ -234,7 +236,7 @@ class HarnessTestCase(unittest.TestCase):
         loaded_tc_harness = Harness.load(
             save_dir=save_dir,
             task="text-classification",
-            model={"model": "lvwerra/distilbert-imdb", "hub": "huggingface"}
+            model={"model": "lvwerra/distilbert-imdb", "hub": "huggingface"},
         )
         self.assertEqual(tc_harness._config, loaded_tc_harness._config)
         self.assertEqual(tc_harness.data, loaded_tc_harness.data)
@@ -259,7 +261,7 @@ class HarnessTestCase(unittest.TestCase):
         loaded_tc_harness = Harness.load(
             save_dir=save_dir,
             task="ner",
-            model = {"model":"dslim/bert-base-NER", "hub":"huggingface"}
+            model={"model": "dslim/bert-base-NER", "hub": "huggingface"},
         )
         self.assertEqual(tc_harness._config, loaded_tc_harness._config)
         self.assertEqual(tc_harness.data, loaded_tc_harness.data)

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -131,7 +131,7 @@ class HarnessTestCase(unittest.TestCase):
         self.harness.save(save_dir)
 
         loaded_harness = Harness.load(
-            save_dir=save_dir, task="ner", model="bert-base-cased", hub="huggingface"
+            save_dir=save_dir, task="ner", model={"model":"bert-base-cased", "hub":"huggingface"}
         )
         self.assertEqual(self.harness._config, loaded_harness._config)
         self.assertEqual(self.harness.data, loaded_harness.data)
@@ -154,8 +154,7 @@ class HarnessTestCase(unittest.TestCase):
         loaded_tc_harness = Harness.load(
             save_dir=save_dir,
             task="text-classification",
-            model="bert-base-cased",
-            hub="huggingface",
+            model={"model": "bert-base-cased", "hub": "huggingface"}
         )
         self.assertEqual(tc_harness._config, loaded_tc_harness._config)
         self.assertEqual(tc_harness.data, loaded_tc_harness.data)
@@ -178,8 +177,7 @@ class HarnessTestCase(unittest.TestCase):
         loaded_tc_harness = Harness.load(
             save_dir=save_dir,
             task="text-classification",
-            model="aychang/roberta-base-imdb",
-            hub="huggingface",
+            model={"model": "aychang/roberta-base-imdb", "hub": "huggingface"}
         )
         self.assertEqual(tc_harness._config, loaded_tc_harness._config)
         self.assertEqual(tc_harness.data, loaded_tc_harness.data)
@@ -236,8 +234,7 @@ class HarnessTestCase(unittest.TestCase):
         loaded_tc_harness = Harness.load(
             save_dir=save_dir,
             task="text-classification",
-            model="lvwerra/distilbert-imdb",
-            hub="huggingface",
+            model={"model": "lvwerra/distilbert-imdb", "hub": "huggingface"}
         )
         self.assertEqual(tc_harness._config, loaded_tc_harness._config)
         self.assertEqual(tc_harness.data, loaded_tc_harness.data)
@@ -262,8 +259,7 @@ class HarnessTestCase(unittest.TestCase):
         loaded_tc_harness = Harness.load(
             save_dir=save_dir,
             task="ner",
-            model="dslim/bert-base-NER",
-            hub="huggingface",
+            model = {"model":"dslim/bert-base-NER", "hub":"huggingface"}
         )
         self.assertEqual(tc_harness._config, loaded_tc_harness._config)
         self.assertEqual(tc_harness.data, loaded_tc_harness.data)


### PR DESCRIPTION
# Description
- Model Selection Option
Provided users with an option to choose the model for evaluation. By default, loaded the GPT models for better evaluation, as some models may not have performed well in instruction tuning, leading to suboptimal results.

 - Save harness.run() Results
Implemented the functionality to save the results obtained from harness.run(). This enabled users to directly import the results and make necessary changes in the evaluation without rerunning the model. This enhancement facilitated a more efficient and flexible evaluation process.

-------------------------------------------------------------------------------------------------
-  Fixes #895

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Usage
<!-- If applicable: show a code snippet or a command on how to use this new addition -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I've added Google style docstrings to my code.
- [ ] I've used `pydantic` for typing when/where necessary.
- [x] I have linted my code
- [x] I have added tests to cover my changes.

## Screenshots (if appropriate):