### PR TITLE
Using LLM to generate sample templates in templatic augmentation method

### DIFF
--- a/langtest/augmentation/__init__.py
+++ b/langtest/augmentation/__init__.py
@@ -325,7 +325,7 @@ class TemplaticAugment(BaseAugmentaion):
         if generate_templates:
             if try_import_lib("openai"):
                  import openai
-                 given_template = self.__templates
+                 given_template = self.__templates[:]
                  for template in given_template:
                         prompt = f"""Based on the template provided, create 10 new and unique templates that are variations on this theme. Present these as a Python list, with each template as a quoted string. The list should contain only the templates without any additional text or explanation.
 
@@ -335,36 +335,30 @@ class TemplaticAugment(BaseAugmentaion):
                         Expected Python List Output:
                         ['Template 1', 'Template 2', 'Template 3', ...]  # Replace with actual generated templates
                         """
-                                                
-                        # Generate text using OpenAI
+
                         response = openai.Completion.create(
-                            engine="text-davinci-003",  # Choose the appropriate model
+                            engine="text-davinci-003",
                             prompt=prompt,
                             max_tokens=500,
-                            temperature=0 , 
+                            temperature=0,
                         )
 
-                        generated_response = (response.choices[0].text)
+                        generated_response = response.choices[0].text.strip()
+                        # Process the generated response
+                        if generated_response:
+                            # Assuming the response format is a Python-like list in a string
+                            templates_list = generated_response.strip("[]").split('",')
+                            templates_list = [template.strip().strip('"') for template in templates_list if template.strip()]
 
-                        templates_list = generated_response.split('",')
-                        templates_list = [template.strip().strip('"') + '"' for template in templates_list if template.strip()]
-
-                        # Fixing the last element (remove the extra quote if it exists)
-                        if templates_list:
-                            templates_list[-1] = templates_list[-1].rstrip('"')
-
-                        # Verify that 'templates_list' is indeed a list
-                        if isinstance(templates_list, list):
+                            # Extend the existing templates list
                             self.__templates.extend(templates_list)
                         else:
-                            # Handle the case where 'templates_list' is not a list
-                            print("Error: generated_response is not a list.")
-                        
+                            print("No response or unexpected format.")
+                                                
                       
             else:
                 path="text-davinci-003"
                 raise ValueError(Errors.E044.format(path=path))
-
         if isinstance(self.__templates, str) and os.path.exists(self.__templates):
             self.__templates = DataFactory(self.__templates, self.__task).load()
         elif isinstance(self.__templates, str):

--- a/langtest/augmentation/__init__.py
+++ b/langtest/augmentation/__init__.py
@@ -328,11 +328,15 @@ class TemplaticAugment(BaseAugmentaion):
                 # Define the prompt
               
                  for template in self.__templates:
-                        prompt = f"""You have been given the following template. Use this template to generate 10 similar templates to it. 
-                        {template}
-                        
+                        prompt = f"""Based on the template provided, create 10 new and unique templates that are variations on this theme. Present these as a Python list, with each template as a quoted string. The list should contain only the templates without any additional text or explanation.
+
+                        Template:
+                        "{template}"
+
+                        Expected Python List Output:
+                        ['Template 1', 'Template 2', 'Template 3', ...]  # Replace with actual generated templates
                         """
-                        
+                                                
                         # Generate text using OpenAI
                         response = openai.Completion.create(
                             engine="text-davinci-003",  # Choose the appropriate model

--- a/langtest/augmentation/__init__.py
+++ b/langtest/augmentation/__init__.py
@@ -366,8 +366,8 @@ class TemplaticAugment(BaseAugmentaion):
                         print("No response or unexpected format.")
 
             else:
-                path = "text-davinci-003"
-                raise ValueError(Errors.E044.format(path=path))
+                raise RuntimeError(Errors.E084)
+    
         if isinstance(self.__templates, str) and os.path.exists(self.__templates):
             self.__templates = DataFactory(self.__templates, self.__task).load()
         elif isinstance(self.__templates, str):

--- a/langtest/augmentation/__init__.py
+++ b/langtest/augmentation/__init__.py
@@ -325,9 +325,8 @@ class TemplaticAugment(BaseAugmentaion):
         if generate_templates:
             if try_import_lib("openai"):
                  import openai
-                # Define the prompt
-              
-                 for template in self.__templates:
+                 given_template = self.__templates
+                 for template in given_template:
                         prompt = f"""Based on the template provided, create 10 new and unique templates that are variations on this theme. Present these as a Python list, with each template as a quoted string. The list should contain only the templates without any additional text or explanation.
 
                         Template:
@@ -341,15 +340,25 @@ class TemplaticAugment(BaseAugmentaion):
                         response = openai.Completion.create(
                             engine="text-davinci-003",  # Choose the appropriate model
                             prompt=prompt,
-                            max_tokens=500  # Adjust the number of tokens as needed
+                            max_tokens=500,
+                            temperature=0 , 
                         )
 
                         generated_response = (response.choices[0].text)
 
-                        parsed_sentences = [line.split('. ', 1)[1] for line in generated_response.strip().split('\n') if line]
+                        templates_list = generated_response.split('",')
+                        templates_list = [template.strip().strip('"') + '"' for template in templates_list if template.strip()]
 
-                        for sentence in parsed_sentences:
-                           self.__templates.append(sentence)
+                        # Fixing the last element (remove the extra quote if it exists)
+                        if templates_list:
+                            templates_list[-1] = templates_list[-1].rstrip('"')
+
+                        # Verify that 'templates_list' is indeed a list
+                        if isinstance(templates_list, list):
+                            self.__templates.extend(templates_list)
+                        else:
+                            # Handle the case where 'templates_list' is not a list
+                            print("Error: generated_response is not a list.")
                         
                       
             else:

--- a/langtest/augmentation/__init__.py
+++ b/langtest/augmentation/__init__.py
@@ -312,7 +312,12 @@ class TemplaticAugment(BaseAugmentaion):
             Performs the templatic augmentation and exports the results to a specified path.
     """
 
-    def __init__(self, templates: Union[str, List[str]], task: TaskManager,  generate_templates = False, ) -> None:
+    def __init__(
+        self,
+        templates: Union[str, List[str]],
+        task: TaskManager,
+        generate_templates=False,
+    ) -> None:
         """This constructor for the TemplaticAugment class.
 
         Args:
@@ -324,10 +329,11 @@ class TemplaticAugment(BaseAugmentaion):
 
         if generate_templates:
             if try_import_lib("openai"):
-                 import openai
-                 given_template = self.__templates[:]
-                 for template in given_template:
-                        prompt = f"""Based on the template provided, create 10 new and unique templates that are variations on this theme. Present these as a Python list, with each template as a quoted string. The list should contain only the templates without any additional text or explanation.
+                import openai
+
+                given_template = self.__templates[:]
+                for template in given_template:
+                    prompt = f"""Based on the template provided, create 10 new and unique templates that are variations on this theme. Present these as a Python list, with each template as a quoted string. The list should contain only the templates without any additional text or explanation.
 
                         Template:
                         "{template}"
@@ -336,28 +342,31 @@ class TemplaticAugment(BaseAugmentaion):
                         ['Template 1', 'Template 2', 'Template 3', ...]  # Replace with actual generated templates
                         """
 
-                        response = openai.Completion.create(
-                            engine="text-davinci-003",
-                            prompt=prompt,
-                            max_tokens=500,
-                            temperature=0,
-                        )
+                    response = openai.Completion.create(
+                        engine="text-davinci-003",
+                        prompt=prompt,
+                        max_tokens=500,
+                        temperature=0,
+                    )
 
-                        generated_response = response.choices[0].text.strip()
-                        # Process the generated response
-                        if generated_response:
-                            # Assuming the response format is a Python-like list in a string
-                            templates_list = generated_response.strip("[]").split('",')
-                            templates_list = [template.strip().strip('"') for template in templates_list if template.strip()]
+                    generated_response = response.choices[0].text.strip()
+                    # Process the generated response
+                    if generated_response:
+                        # Assuming the response format is a Python-like list in a string
+                        templates_list = generated_response.strip("[]").split('",')
+                        templates_list = [
+                            template.strip().strip('"')
+                            for template in templates_list
+                            if template.strip()
+                        ]
 
-                            # Extend the existing templates list
-                            self.__templates.extend(templates_list)
-                        else:
-                            print("No response or unexpected format.")
-                                                
-                      
+                        # Extend the existing templates list
+                        self.__templates.extend(templates_list)
+                    else:
+                        print("No response or unexpected format.")
+
             else:
-                path="text-davinci-003"
+                path = "text-davinci-003"
                 raise ValueError(Errors.E044.format(path=path))
         if isinstance(self.__templates, str) and os.path.exists(self.__templates):
             self.__templates = DataFactory(self.__templates, self.__task).load()
@@ -372,7 +381,6 @@ class TemplaticAugment(BaseAugmentaion):
         output_path: str,
         max_num: int = None,
         append_original: bool = False,
-      
         *args,
         **kwargs,
     ) -> bool:
@@ -401,7 +409,7 @@ class TemplaticAugment(BaseAugmentaion):
             else []
         )
         self.__search_results = self.search_sample_results(data)
-                
+
         if not max_num:
             max_num = max(len(i) for i in self.__search_results.values())
 

--- a/langtest/augmentation/__init__.py
+++ b/langtest/augmentation/__init__.py
@@ -367,7 +367,7 @@ class TemplaticAugment(BaseAugmentaion):
 
             else:
                 raise RuntimeError(Errors.E084)
-    
+
         if isinstance(self.__templates, str) and os.path.exists(self.__templates):
             self.__templates = DataFactory(self.__templates, self.__task).load()
         elif isinstance(self.__templates, str):

--- a/langtest/errors.py
+++ b/langtest/errors.py
@@ -225,6 +225,7 @@ class Errors(metaclass=ErrorsWithCodes):
     E081 = ("Provded the task is not supported in the {hub} hub.")
     E082 = ("Either subset: {subset} or split: {split} is not valid for {dataset_name}. Available subsets and their corresponding splits: {available_subset_splits}")
     E083 = ("split: {split} is not valid for {dataset_name}. Available splits: {available_splits}")
+    E084 = ("OpenAI not installed. Install using !pip install openai==0.28.1 and set the openai.api_key = 'YOUR KEY' ")
 
 
 class ColumnNameError(Exception):

--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -693,12 +693,11 @@ class Harness:
             _ = TemplaticAugment(
                 templates=templates,
                 task=self.task,
-                generate_templates = generate_templates,
+                generate_templates=generate_templates,
             ).fix(
                 training_data=training_data,
                 output_path=save_data_path,
                 append_original=append_original,
-                
             )
 
         else:

--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -629,6 +629,7 @@ class Harness:
         export_mode: str = "add",
         templates: Optional[Union[str, List[str]]] = None,
         append_original: bool = False,
+        generate_templates: bool = False,
     ) -> "Harness":
         """Augments the data in the input file located at `input_path` and saves the result to `output_path`.
 
@@ -692,10 +693,12 @@ class Harness:
             _ = TemplaticAugment(
                 templates=templates,
                 task=self.task,
+                generate_templates = generate_templates,
             ).fix(
                 training_data=training_data,
                 output_path=save_data_path,
                 append_original=append_original,
+                
             )
 
         else:


### PR DESCRIPTION
# Description
Enable users to generate sample templates using LLMs and then use them in templatic augmentation.

## Screenshots (if appropriate):

### Usage:

![image](https://github.com/JohnSnowLabs/langtest/assets/71844877/2a112920-079d-4b83-a836-4fe6d592f182)

set `generate_templates` = True

### Obtained Augmentations:

![image](https://github.com/JohnSnowLabs/langtest/assets/71844877/7de22f03-d6e4-45cb-b001-5869f5449bdc)
