### PR TITLE
Fix/sparknlp lib without johnsnowlabs

### DIFF
--- a/langtest/modelhandler/__init__.py
+++ b/langtest/modelhandler/__init__.py
@@ -5,6 +5,9 @@ import langtest.modelhandler.custom_modelhandler
 RENAME_HUBS = {
     "azureopenai": "azure-openai",
     "huggingfacehub": "huggingface-inference-api",
+    "sparknlp": "johnsnowlabs",
+    "pyspark": "johnsnowlabs",
+    "transformers": "huggingface",
 }
 
 INSTALLED_HUBS = ["custom"]
@@ -22,8 +25,10 @@ libraries = [
 for library_name, import_statement in libraries:
     if importlib.util.find_spec(library_name):
         importlib.import_module(import_statement)
-        if library_name in ("transformers"):
-            INSTALLED_HUBS.append("huggingface")
+        # if library_name in ("transformers"):
+        #     INSTALLED_HUBS.append("huggingface")
+        if library_name in RENAME_HUBS:
+            INSTALLED_HUBS.append(RENAME_HUBS[library_name])
         else:
             INSTALLED_HUBS.append(library_name)
 

--- a/langtest/modelhandler/__init__.py
+++ b/langtest/modelhandler/__init__.py
@@ -25,8 +25,6 @@ libraries = [
 for library_name, import_statement in libraries:
     if importlib.util.find_spec(library_name):
         importlib.import_module(import_statement)
-        # if library_name in ("transformers"):
-        #     INSTALLED_HUBS.append("huggingface")
         if library_name in RENAME_HUBS:
             INSTALLED_HUBS.append(RENAME_HUBS[library_name])
         else:

--- a/langtest/modelhandler/__init__.py
+++ b/langtest/modelhandler/__init__.py
@@ -11,6 +11,9 @@ INSTALLED_HUBS = ["custom"]
 
 libraries = [
     ("johnsnowlabs", "langtest.modelhandler.jsl_modelhandler"),
+    ("sparknlp", "langtest.modelhandler.jsl_modelhandler"),
+    ("pyspark", "langtest.modelhandler.jsl_modelhandler"),
+    ("johnsnowlabs", "langtest.modelhandler.jsl_modelhandler"),
     ("transformers", "langtest.modelhandler.transformers_modelhandler"),
     ("spacy", "langtest.modelhandler.spacy_modelhandler"),
     ("langchain", "langtest.modelhandler.llm_modelhandler"),


### PR DESCRIPTION
I've updated the initialization file in modelhandler to support SparkNLP without requiring the installation of JohnSnowLabs.