### PR TITLE
User prompt handling for multi-dataset testing

### DIFF
--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -1572,8 +1572,18 @@ class Harness:
     ):
         generated_results = {}
 
+        # temp_store_prompt
+        temp_store_prompt = self._config.get("model_parameters", {}).get(
+            "user_prompt", None
+        )
+
         # Run the testcases for each dataset
         for dataset_name, samples in testcases.items():
+            # update user prompt for each dataset
+            if temp_store_prompt:
+                self._config.get("model_parameters", {}).update(
+                    {"user_prompt": temp_store_prompt.get(dataset_name)}
+                )
             # Get the raw data for the dataset
             if isinstance(self.data, dict):
                 raw_data = self.data.get(dataset_name)
@@ -1596,6 +1606,12 @@ class Harness:
                 )
 
             print(f"{'':-^80}\n")
+
+        # resore user prompt
+        if temp_store_prompt:
+            self._config.get("model_parameters", {}).update(
+                {"user_prompt": temp_store_prompt}
+            )
 
         if (
             self.is_multi_dataset

--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -1580,7 +1580,7 @@ class Harness:
         # Run the testcases for each dataset
         for dataset_name, samples in testcases.items():
             # update user prompt for each dataset
-            if temp_store_prompt:
+            if temp_store_prompt and isinstance(temp_store_prompt, dict):
                 self._config.get("model_parameters", {}).update(
                     {"user_prompt": temp_store_prompt.get(dataset_name)}
                 )


### PR DESCRIPTION
The following way to configure the multi-prompt for multi-dataset testing 

```python
harness = Harness(
    task="question-answering",
    model={"model": "http://localhost:1234/v1/chat/completions", "hub": "lm-studio"},
    data=[
        {"data_source": "BoolQ", "split": "test-tiny"},
        {"data_source": "NQ-open", "split": "test-tiny"},
        {"data_source": "MedQA", "split": "test-tiny"},
        {"data_source": "LogiQA", "split": "test-tiny"},
    ],
    config={
        "model_parameters": {
            "max_tokens": 64,
            "user_prompt": {
                "BoolQ": "Answer the following question with a yes or no: {question}",
                "NQ-open": "Answer the following question with a short answer: {question}",
                "MedQA": "Answer the following medical question: {question} {options}",
                "LogiQA": "Answer the following logic question: {question} {options}"
            }
        },
        "tests": {
            "defaults": {
                "min_pass_rate": 1.0
            },
            "robustness": {
                "add_typo": {
                    "min_pass_rate": 0.7
                },
                "lowercase": {
                    "min_pass_rate": 0.7
                }
            }
        }
    }
)
```