### PR TITLE
`random_age` Class not returning test cases

### DIFF
--- a/langtest/transform/robustness.py
+++ b/langtest/transform/robustness.py
@@ -1680,12 +1680,12 @@ class RandomAge(BaseRobustness):
             for i in range(count):
                 if isinstance(sample, str):
                     s, _ = randomize_ages(sample)
-                    perturbed_samples.append(s)
                 else:
                     s = deepcopy(sample)
                     s.test_case, transformations = randomize_ages(s.original)
                     if s.task in ("ner", "text-classification"):
                         s.transformations = transformations
                     s.category = "robustness"
+                perturbed_samples.append(s)
 
         return perturbed_samples


### PR DESCRIPTION
This pull request rectifies a bug in the `randomize_age` Test within langtest. Previously, the function failed to return the generated test cases after processing the input samples.

**Details:**

The issue stemmed from placing the `append` statement within the loop iterating over samples. Originally, the `append` was placed after the loop, resulting in the generated test cases not being added to the `perturbed_samples` list.
The fix involves moving the append statement inside the loop after the test case and generating transformations using `randomize_ages(s.original)`. This ensures that each processed sample's test case is captured before moving on to the next iteration.

**Benefits:**

This fix guarantees that the `randomize_ages` function correctly returns the generated test cases, enabling proper execution of the testing suite.
By successfully returning the test cases, you can validate your language processing capabilities for handling age-related scenarios within your robustness testing framework.