### PR TITLE
Add support to the LLM eval class in Accuracy Category.

### DIFF
--- a/langtest/transform/accuracy.py
+++ b/langtest/transform/accuracy.py
@@ -998,13 +998,17 @@ class LLMEval(BaseAccuracy):
 
         model = params.get("model", None)
         hub = params.get("hub", None)
+
+        # get model parameters from tests config or harness config if not provided
+        # if not provided, default to the default model parameters
+        parameters = params.get(
+            "model_parameters", harness_config.get("model_parameters", {})
+        )
         if model and hub:
             from ..tasks import TaskManager
 
             load_eval_model = TaskManager("question-answering")
-            cls.eval_model = load_eval_model.model(
-                model, hub, **harness_config.get("model_parameters", {})
-            )
+            cls.eval_model = load_eval_model.model(model, hub, **parameters)
 
         else:
             cls.eval_model = EVAL_MODEL


### PR DESCRIPTION
- Fix to support the parameters separately from the testing model and evaluation model.

```yaml
# config.yaml
model_parameters:
  max_tokens: 64
  task: text2text-generation
tests:
  defaults:
    min_pass_rate: 0.65
  robustness:
    add_typo:
      min_pass_rate: 0.7
  accuracy:
    llm_eval:
      hub: huggingface
      min_score: 1.0
      model: prometheus-eval/prometheus-7b-v2.0
      model_parameters:
        max_tokens: 64
        task: text-generation

```
harness setup:

```python
h = Harness(
    task='question-answering',
    model={'model': 'google/flan-t5-base', 'hub': 'huggingface'},
    data={'data_source': 'MedMCQA'},
    config="config.yaml"
)
```