### PR TITLE
Fix/error in accuracy tests for ner task

### DIFF
--- a/langtest/utils/util_metrics.py
+++ b/langtest/utils/util_metrics.py
@@ -1,6 +1,7 @@
 from collections import Counter
 from typing import List, Set, Union, Dict
 from ..errors import Errors
+import pandas as pd
 
 
 def classification_report(
@@ -99,7 +100,13 @@ def calculate_f1_score(
     """
     assert len(y_true) == len(y_pred), "Lengths of y_true and y_pred must be equal."
 
-    unique_labels = set(y_true + y_pred)
+    if isinstance(y_true, list) and isinstance(y_pred, list):
+        unique_labels = set(y_true + y_pred)
+    elif isinstance(y_true, pd.Series) and isinstance(y_pred, pd.Series):
+        unique_labels = set(y_true.tolist() + y_pred.tolist())
+    else:
+        raise ValueError("y_true and y_pred must be of the same type. Supported types are list and pandas Series.")
+    
     num_classes = len(unique_labels)
 
     if average == "micro":

--- a/langtest/utils/util_metrics.py
+++ b/langtest/utils/util_metrics.py
@@ -105,8 +105,10 @@ def calculate_f1_score(
     elif isinstance(y_true, pd.Series) and isinstance(y_pred, pd.Series):
         unique_labels = set(y_true.tolist() + y_pred.tolist())
     else:
-        raise ValueError("y_true and y_pred must be of the same type. Supported types are list and pandas Series.")
-    
+        raise ValueError(
+            "y_true and y_pred must be of the same type. Supported types are list and pandas Series."
+        )
+
     num_classes = len(unique_labels)
 
     if average == "micro":


### PR DESCRIPTION
update the calculate_f1_score function in **/langtest\utils\util_metrics.py**
```python
    if isinstance(y_true, list) and isinstance(y_pred, list):
        unique_labels = set(y_true + y_pred)
    elif isinstance(y_true, pd.Series) and isinstance(y_pred, pd.Series):
        unique_labels = set(y_true.tolist() + y_pred.tolist())
    else:
        raise ValueError(
            "y_true and y_pred must be of the same type. Supported types are list and pandas Series."
        )

```