### PR TITLE
updated: model_kwargs handling for evaluation model

### DIFF
--- a/langtest/modelhandler/llm_modelhandler.py
+++ b/langtest/modelhandler/llm_modelhandler.py
@@ -110,11 +110,7 @@ class PretrainedModelForQA(ModelAPI):
                     model = AzureChatOpenAI(model=path, *args, **filtered_kwargs)
 
                 return cls(hub, model, *args, **filtered_kwargs)
-            # elif hub == "ollama":
-            #     from langchain.chat_models.ollama import ChatOllama
 
-            #     model = ChatOllama(model=path, *args, **filtered_kwargs)
-            #     return cls(hub, model, *args, **filtered_kwargs)
             else:
                 from .utils import CHAT_MODEL_CLASSES
 
@@ -136,6 +132,9 @@ class PretrainedModelForQA(ModelAPI):
                 cls.model = model(model_id=path, *args, **filtered_kwargs)
             elif "repo_id" in default_args:
                 cls.model = model(repo_id=path, model_kwargs=filtered_kwargs)
+            # mapping path dict to model object
+            else:
+                cls.model = model(**path)
             return cls(hub, cls.model, *args, **filtered_kwargs)
 
         except ImportError:

--- a/langtest/utils/custom_types/sample.py
+++ b/langtest/utils/custom_types/sample.py
@@ -546,12 +546,17 @@ class QASample(BaseQASample):
                 if harness_config["evaluation"]["metric"].lower() == "llm_eval":
                     model = harness_config["evaluation"].get("model", None)
                     hub = harness_config["evaluation"].get("hub", None)
+                    model_parameters = harness_config["evaluation"].get(
+                        "model_parameters", None
+                    )
+                    if model_parameters is None:
+                        model_parameters = harness_config.get("model_parameters", {})
                     if model and hub:
                         from ...tasks import TaskManager
 
                         load_eval_model = TaskManager(self.task)
                         self.eval_model = load_eval_model.model(
-                            model, hub, **harness_config.get("model_parameters", {})
+                            model, hub, **model_parameters
                         )
 
             else:


### PR DESCRIPTION
This pull request includes updates to the `load_model` method in the `langtest/modelhandler/llm_modelhandler.py` file. The changes mainly involve cleaning up commented-out code and adding a new handling case for mapping a path dictionary to a model object.

Code cleanup and new handling case:

* Removed commented-out code related to the `ollama` hub. (`langtest/modelhandler/llm_modelhandler.py`, [langtest/modelhandler/llm_modelhandler.pyL113-L117](diffhunk://#diff-db9a56182e28a58addb4e30e66a8aad3d440d8a0ea6632e364bf5321f27e8b05L113-L117))
* Added a new case to map a path dictionary to a model object. (`langtest/modelhandler/llm_modelhandler.py`, [langtest/modelhandler/llm_modelhandler.pyR135-R137](diffhunk://#diff-db9a56182e28a58addb4e30e66a8aad3d440d8a0ea6632e364bf5321f27e8b05R135-R137))