### PR TITLE
Feature/random masking on images tests

### DIFF
--- a/langtest/transform/image/robustness.py
+++ b/langtest/transform/image/robustness.py
@@ -332,28 +332,6 @@ class ImageShear(BaseRobustness):
         return sample_list
 
 
-class MaskedImage(BaseRobustness):
-    alias_name = "masked_image"
-    supported_tasks = ["visualqa"]
-
-    @staticmethod
-    def transform(
-        sample_list: List[Sample],
-        mask: Union[Image.Image, str],
-        *args,
-        **kwargs,
-    ) -> List[Sample]:
-        for sample in sample_list:
-            sample.category = "robustness"
-            sample.test_type = "masked_image"
-            sample.perturbed_image = sample.original_image.copy()
-            if isinstance(mask, str):
-                mask = Image.open(mask)
-            sample.perturbed_image.paste(mask, (0, 0), mask)
-
-        return sample_list
-
-
 class ImageCorruptor(BaseRobustness):
     """
     This class is used to corrupt the image by adding a black box to it.

--- a/langtest/transform/image/robustness.py
+++ b/langtest/transform/image/robustness.py
@@ -332,12 +332,12 @@ class ImageShear(BaseRobustness):
         return sample_list
 
 
-class ImageCorruptor(BaseRobustness):
+class ImageBlackSpot(BaseRobustness):
     """
     This class is used to corrupt the image by adding a black box to it.
     """
 
-    alias_name = "image_corruption"
+    alias_name = "image_black_spots"
     supported_tasks = ["visualqa"]
 
     @staticmethod
@@ -351,7 +351,7 @@ class ImageCorruptor(BaseRobustness):
     ) -> List[Sample]:
         for sample in sample_list:
             sample.category = "robustness"
-            sample.test_type = "image_corruption"
+            sample.test_type = "image_black_spots"
             sample.perturbed_image = sample.original_image.copy()
             for _ in range(max_count):
                 random_size = random.randint(*size_range)

--- a/langtest/transform/image/robustness.py
+++ b/langtest/transform/image/robustness.py
@@ -284,3 +284,71 @@ class ImageCrop(BaseRobustness):
                 )
 
         return sample_list
+
+
+class ImageTranslate(BaseRobustness):
+    alias_name = "image_translate"
+    supported_tasks = ["visualqa"]
+
+    @staticmethod
+    def transform(
+        sample_list: List[Sample],
+        translate: Tuple[int, int] = (10, 10),
+        *args,
+        **kwargs,
+    ) -> List[Sample]:
+        for sample in sample_list:
+            sample.category = "robustness"
+            sample.test_type = "image_translate"
+            sample.perturbed_image = sample.original_image.transform(
+                sample.original_image.size,
+                Image.AFFINE,
+                (1, 0, translate[0], 0, 1, translate[1]),
+            )
+
+        return sample_list
+
+
+class ImageShear(BaseRobustness):
+    alias_name = "image_shear"
+    supported_tasks = ["visualqa"]
+
+    @staticmethod
+    def transform(
+        sample_list: List[Sample],
+        shear: float = 0.5,
+        *args,
+        **kwargs,
+    ) -> List[Sample]:
+        for sample in sample_list:
+            sample.category = "robustness"
+            sample.test_type = "image_shear"
+            sample.perturbed_image = sample.original_image.transform(
+                sample.original_image.size,
+                Image.AFFINE,
+                (1, shear, 0, 0, 1, 0),
+            )
+
+        return sample_list
+
+
+class MaskedImage(BaseRobustness):
+    alias_name = "masked_image"
+    supported_tasks = ["visualqa"]
+
+    @staticmethod
+    def transform(
+        sample_list: List[Sample],
+        mask: Union[Image.Image, str],
+        *args,
+        **kwargs,
+    ) -> List[Sample]:
+        for sample in sample_list:
+            sample.category = "robustness"
+            sample.test_type = "masked_image"
+            sample.perturbed_image = sample.original_image.copy()
+            if isinstance(mask, str):
+                mask = Image.open(mask)
+            sample.perturbed_image.paste(mask, (0, 0), mask)
+
+        return sample_list

--- a/langtest/transform/image/robustness.py
+++ b/langtest/transform/image/robustness.py
@@ -424,3 +424,32 @@ class ImageLayeredMask(BaseRobustness):
             sample.perturbed_image.paste(mask, (0, 0), mask)
 
         return sample_list
+
+
+class ImageTextOverlay(BaseRobustness):
+    alias_name = "image_text_overlay"
+    supported_tasks = ["visualqa"]
+
+    @staticmethod
+    def transform(
+        sample_list: List[Sample],
+        text: str = "Hello, World!",
+        font_size: int = 20,
+        font_color: Tuple[int, int, int] = (255, 255, 255),
+        position: Tuple[int, int] = (10, 10),
+        *args,
+        **kwargs,
+    ) -> List[Sample]:
+        from PIL import ImageFont
+
+        for sample in sample_list:
+            sample.category = "robustness"
+            sample.test_type = "image_text_overlay"
+            sample.perturbed_image = sample.original_image.copy()
+            draw = ImageDraw.Draw(sample.perturbed_image)
+            font = ImageFont.load_default()
+            draw.text(
+                position, text, font=font, fill=font_color,
+            )
+
+        return sample_list

--- a/langtest/transform/image/robustness.py
+++ b/langtest/transform/image/robustness.py
@@ -449,7 +449,10 @@ class ImageTextOverlay(BaseRobustness):
             draw = ImageDraw.Draw(sample.perturbed_image)
             font = ImageFont.load_default()
             draw.text(
-                position, text, font=font, fill=font_color,
+                position,
+                text,
+                font=font,
+                fill=font_color,
             )
 
         return sample_list


### PR DESCRIPTION
This pull request adds several new image transformation classes to the `langtest/transform/image/robustness.py` file, enhancing the robustness testing capabilities for visual QA tasks. The most significant changes include the addition of multiple transformation classes and the inclusion of new image manipulation utilities.

New image transformation classes:

* Added `ImageTranslate` class to apply translation transformations to images.
* Added `ImageShear` class to apply shear transformations to images.
* Added `ImageBlackSpot` class to corrupt images by adding black spots.
* Added `ImageLayeredMask` class to apply layered mask transformations with optional flipping.
* Added `ImageTextOverlay` class to overlay text on images.
* Added `ImageWatermark` class to apply watermark transformations to images.

Enhancements to image manipulation utilities:

* Imported `ImageDraw` module to support drawing operations required by the new transformations.
* Added `Literal` type import to support type annotations for specific string values.