### PR TITLE
Annotations/improve the type annotation for config

### DIFF
--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -13,7 +13,7 @@ import random
 
 from pkg_resources import resource_filename
 
-from langtest.types import DatasetConfig, ModelConfig
+from langtest.types import DatasetConfig, HarnessConfig, ModelConfig
 
 from .tasks import TaskManager
 from .augmentation import AugmentRobustness, TemplaticAugment
@@ -94,18 +94,18 @@ class Harness:
         task: Union[str, dict],
         model: Optional[Union[List[ModelConfig], ModelConfig]] = None,
         data: Optional[Union[List[DatasetConfig], DatasetConfig]] = None,
-        config: Optional[Union[str, dict]] = None,
+        config: Optional[Union[HarnessConfig, str]] = None,
         benchmarking: dict = None,
     ):
         """Initialize the Harness object.
 
         Args:
             task (str, optional): Task for which the model is to be evaluated.
-            model (list | dict, optional): Specifies the model to be evaluated.
+            model (ModelConfig, list | dict, optional): Specifies the model to be evaluated.
                 If provided as a list, each element should be a dictionary with 'model' and 'hub' keys.
                 If provided as a dictionary, it must contain 'model' and 'hub' keys when specifying a path.
-            data (dict, optional): The data to be used for evaluation.
-            config (str | dict, optional): Configuration for the tests to be performed.
+            data (DatasetConfig, dict, optional): The data to be used for evaluation.
+            config (str | HarnessConfig , optional): Configuration for the tests to be performed.
 
         Raises:
             ValueError: Invalid arguments.
@@ -251,7 +251,7 @@ class Harness:
     def __str__(self) -> str:
         return object.__repr__(self)
 
-    def configure(self, config: Union[str, dict]) -> dict:
+    def configure(self, config: Union[HarnessConfig, dict, str]) -> HarnessConfig:
         """Configure the Harness with a given configuration.
 
         Args:

--- a/langtest/transform/accuracy.py
+++ b/langtest/transform/accuracy.py
@@ -2,7 +2,7 @@ import asyncio
 from collections import defaultdict
 import pandas as pd
 from abc import ABC, abstractmethod
-from typing import Any, DefaultDict, Dict, List, Type, Union
+from typing import Any, DefaultDict, Dict, List, Type, TypedDict, Union
 
 from langtest.modelhandler.modelhandler import ModelAPI
 from langtest.transform.base import ITests
@@ -271,6 +271,11 @@ class BaseAccuracy(ABC):
 
     alias_name = None
     supported_tasks = ["ner", "text-classification"]
+
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_score=Union[Dict[str, float], float],
+    )
 
     @classmethod
     @abstractmethod
@@ -1019,6 +1024,13 @@ class LLMEval(BaseAccuracy):
     supported_tasks = ["question-answering"]
 
     eval_model = None
+
+    TestConfig = TypedDict(
+        "TestConfig",
+        model=str,
+        hub=str,
+        min_score=float,
+    )
 
     @classmethod
     def transform(

--- a/langtest/transform/bias.py
+++ b/langtest/transform/bias.py
@@ -4,7 +4,7 @@ import random
 from langtest.logger import logger as logging
 import re
 from abc import ABC, abstractmethod
-from typing import Dict, List
+from typing import Dict, List, TypedDict
 
 from langtest.modelhandler.modelhandler import ModelAPI
 from langtest.transform.base import ITests, TestFactory
@@ -246,6 +246,9 @@ class BaseBias(ABC):
         "question-answering",
         "summarization",
     ]
+
+    # Config Hint for the bias tests
+    TestConfig = TypedDict("TestConfig", min_pass_rate=float)
 
     @abstractmethod
     def transform(self, sample_list: List[Sample], *args, **kwargs) -> List[Sample]:

--- a/langtest/transform/bias.py
+++ b/langtest/transform/bias.py
@@ -210,7 +210,7 @@ class BiasTestFactory(ITests):
         return all_samples
 
     @staticmethod
-    def available_tests() -> Dict:
+    def available_tests() -> Dict[str, type["BaseBias"]]:
         """
         Get a dictionary of all available tests, with their names as keys and their corresponding classes as values.
 

--- a/langtest/transform/clinical.py
+++ b/langtest/transform/clinical.py
@@ -3,7 +3,7 @@ import asyncio
 from collections import defaultdict
 import logging
 import random
-from typing import List, Dict, Union
+from typing import List, Dict, TypedDict, Union
 
 import importlib_resources
 from langtest.errors import Errors, Warnings
@@ -100,6 +100,12 @@ class BaseClincial(ABC):
         "question-answering",
     ]
 
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+    )
+
     @staticmethod
     @abstractmethod
     def transform(*args, **kwargs):
@@ -147,7 +153,7 @@ class DemographicBias(BaseClincial):
     DemographicBias class for the clinical tests
     """
 
-    alias_name = "demographic-bias"
+    alias_name = ["demographic-bias", "demographic_bias"]
     supported_tasks = ["question-answering", "text-generation"]
 
     @staticmethod

--- a/langtest/transform/disinformation.py
+++ b/langtest/transform/disinformation.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import List, Dict
+from typing import List, Dict, TypedDict
 from langtest.modelhandler.modelhandler import ModelAPI
 from langtest.transform.base import ITests
 from langtest.utils.custom_types.sample import Sample
@@ -13,6 +13,12 @@ class DisinformationTestFactory(ITests):
         "disinformation",
         "text-generation",
     ]
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+    )
 
     def __init__(self, data_handler: List[Sample], tests: Dict = None, **kwargs) -> None:
         self.data_handler = data_handler

--- a/langtest/transform/factuality.py
+++ b/langtest/transform/factuality.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import List, Dict
+from typing import List, Dict, TypedDict
 from langtest.transform.base import ITests
 from langtest.utils.custom_types.sample import Sample
 from langtest.modelhandler.modelhandler import ModelAPI
@@ -10,6 +10,12 @@ class FactualityTestFactory(ITests):
 
     alias_name = "factuality"
     supported_tasks = ["factuality", "question-answering"]
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+    )
 
     def __init__(self, data_handler: List[Sample], tests: Dict = None, **kwargs) -> None:
         """Initializes the FactualityTestFactory"""

--- a/langtest/transform/fairness.py
+++ b/langtest/transform/fairness.py
@@ -75,7 +75,7 @@ class FairnessTestFactory(ITests):
         return all_samples
 
     @staticmethod
-    def available_tests() -> dict:
+    def available_tests() -> Dict[str, type["BaseFairness"]]:
         """
         Get a dictionary of all available tests, with their names as keys and their corresponding classes as values.
 

--- a/langtest/transform/fairness.py
+++ b/langtest/transform/fairness.py
@@ -2,7 +2,7 @@ import asyncio
 import pandas as pd
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import List, Dict, Union
+from typing import List, Dict, TypedDict, Union
 
 from langtest.modelhandler.modelhandler import ModelAPI
 from langtest.utils.custom_types import (
@@ -288,6 +288,12 @@ class BaseFairness(ABC):
     alias_name = None
     supported_tasks = ["ner", "text-classification"]
 
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_score=Union[float, Dict[str, float]],
+        max_score=Union[float, Dict[str, float]],
+    )
+
     @staticmethod
     @abstractmethod
     def transform(
@@ -352,6 +358,18 @@ class MinGenderF1Score(BaseFairness):
     """
 
     alias_name = ["min_gender_f1_score"]
+
+    min_score = TypedDict(
+        "min_score",
+        male=float,
+        female=float,
+        unknown=float,
+    )
+
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_score=Union[min_score, float],
+    )
 
     @classmethod
     def transform(
@@ -455,6 +473,18 @@ class MaxGenderF1Score(BaseFairness):
     """
 
     alias_name = ["max_gender_f1_score"]
+
+    max_score = TypedDict(
+        "max_score",
+        male=float,
+        female=float,
+        unknown=float,
+    )
+
+    TestConfig = TypedDict(
+        "TestConfig",
+        max_score=Union[max_score, float],
+    )
 
     @classmethod
     def transform(
@@ -567,6 +597,18 @@ class MinGenderRougeScore(BaseFairness):
     ]
     supported_tasks = ["question-answering", "summarization"]
 
+    min_score = TypedDict(
+        "min_score",
+        male=float,
+        female=float,
+        unknown=float,
+    )
+
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_score=Union[min_score, float],
+    )
+
     @classmethod
     def transform(
         cls, test: str, data: List[Sample], params: Dict
@@ -676,6 +718,18 @@ class MaxGenderRougeScore(BaseFairness):
     ]
     supported_tasks = ["question-answering", "summarization"]
 
+    max_score = TypedDict(
+        "max_score",
+        male=float,
+        female=float,
+        unknown=float,
+    )
+
+    TestConfig = TypedDict(
+        "TestConfig",
+        max_score=Union[max_score, float],
+    )
+
     @classmethod
     def transform(
         cls, test: str, data: List[Sample], params: Dict
@@ -778,6 +832,18 @@ class MinGenderLLMEval(BaseFairness):
     alias_name = ["min_gender_llm_eval"]
     supported_tasks = ["question-answering"]
     eval_model = None
+
+    min_score = TypedDict(
+        "min_score",
+        male=float,
+        female=float,
+        unknown=float,
+    )
+
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_score=Union[min_score, float],
+    )
 
     @classmethod
     def transform(
@@ -914,6 +980,18 @@ class MaxGenderLLMEval(BaseFairness):
     alias_name = ["max_gender_llm_eval"]
     supported_tasks = ["question-answering"]
     eval_model = None
+
+    max_score = TypedDict(
+        "max_score",
+        male=float,
+        female=float,
+        unknown=float,
+    )
+
+    TestConfig = TypedDict(
+        "TestConfig",
+        max_score=Union[max_score, float],
+    )
 
     @classmethod
     def transform(

--- a/langtest/transform/grammar.py
+++ b/langtest/transform/grammar.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, TypedDict
 from langtest.utils.custom_types.sample import Sample
 from abc import ABC, abstractmethod
 from langtest.errors import Errors, Warnings
@@ -103,7 +103,7 @@ class GrammarTestFactory(ITests):
         return all_samples
 
     @staticmethod
-    def available_tests() -> dict:
+    def available_tests() -> Dict[str, type["BaseGrammar"]]:
         """
         Retrieve a dictionary of all available tests, with their names as keys
         and their corresponding classes as values.
@@ -120,9 +120,23 @@ class GrammarTestFactory(ITests):
 
 
 class BaseGrammar(ABC):
+    """
+    BaseGrammar abstract class for implementing to test the model performance on varying the input by grammatically changes .
+
+    """
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+    )
+
     @staticmethod
     @abstractmethod
     def transform(sample_list: List[Sample], *args, **kwargs):
+        """
+        Abstract method that transforms the sample data with grammatically changes.
+        """
         raise NotImplementedError
 
     @staticmethod

--- a/langtest/transform/ideology.py
+++ b/langtest/transform/ideology.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections import defaultdict
-from typing import List, Dict
+from typing import List, Dict, TypedDict
 
 from langtest.modelhandler.modelhandler import ModelAPI
 from langtest.transform.base import ITests
@@ -84,6 +84,11 @@ class BaseIdeology(ABC):
 
     alias_name = None
     supported_tasks = ["ideology", "question-answering"]
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+    )
 
     @abstractmethod
     def transform(self, sample_list: List[Sample], *args, **kwargs) -> List[Sample]:

--- a/langtest/transform/legal.py
+++ b/langtest/transform/legal.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import List, Dict
+from typing import List, Dict, TypedDict
 from langtest.transform.base import ITests
 from langtest.modelhandler.modelhandler import ModelAPI
 from langtest.utils.custom_types.sample import Sample
@@ -10,6 +10,12 @@ class LegalTestFactory(ITests):
 
     alias_name = "legal"
     supported_tasks = ["legal", "question-answering"]
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+    )
 
     def __init__(self, data_handler: List[Sample], tests: Dict = None, **kwargs) -> None:
         """Initializes the legal tests"""

--- a/langtest/transform/performance.py
+++ b/langtest/transform/performance.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from collections import defaultdict
-from typing import List, Dict
+from typing import List, Dict, TypedDict
 from langtest.errors import Errors
 from abc import ABC, abstractmethod
 from langtest.modelhandler.modelhandler import ModelAPI
@@ -73,7 +73,7 @@ class PerformanceTestFactory(ITests):
         return tasks
 
     @classmethod
-    def available_tests(cls) -> Dict[str, str]:
+    def available_tests(cls) -> Dict[str, type["BasePerformance"]]:
         """Returns the available model performance
 
         Returns:
@@ -95,6 +95,12 @@ class BasePerformance(ABC):
     test_types = defaultdict(lambda: BasePerformance)
     alias_name = None
     TOKENS = 0
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+    )
 
     @staticmethod
     @abstractmethod

--- a/langtest/transform/representation.py
+++ b/langtest/transform/representation.py
@@ -74,7 +74,7 @@ class RepresentationTestFactory(ITests):
         return all_samples
 
     @staticmethod
-    def available_tests() -> Dict:
+    def available_tests() -> Dict[str, type["BaseRepresentation"]]:
         """
         Get a dictionary of all available tests, with their names as keys and their corresponding classes as values.
 

--- a/langtest/transform/representation.py
+++ b/langtest/transform/representation.py
@@ -186,8 +186,8 @@ class GenderRepresentation(BaseRepresentation):
     # Config Hint for the representation tests
     TestConfig = TypedDict(
         "TestConfig",
-        min_count=Union[int, min_count],
-        min_proportion=Union[float, min_proportion],
+        min_count=Union[min_count, int],
+        min_proportion=Union[min_proportion, float],
     )
 
     @classmethod
@@ -376,8 +376,8 @@ class EthnicityRepresentation(BaseRepresentation):
 
     TestConfig = TypedDict(
         "TestConfig",
-        min_count=Union[int, min_count],
-        min_proportion=Union[float, min_proportion],
+        min_count=Union[min_count, int],
+        min_proportion=Union[min_proportion, float],
     )
 
     @classmethod
@@ -739,8 +739,8 @@ class ReligionRepresentation(BaseRepresentation):
 
     TestConfig = TypedDict(
         "TestConfig",
-        min_count=Union[int, min_count],
-        min_proportion=Union[float, min_proportion],
+        min_count=Union[min_count, int],
+        min_proportion=Union[min_proportion, float],
     )
 
     @classmethod
@@ -969,8 +969,8 @@ class CountryEconomicRepresentation(BaseRepresentation):
 
     TestConfig = TypedDict(
         "TestConfig",
-        min_count=Union[int, min_count],
-        min_proportion=Union[float, min_proportion],
+        min_count=Union[min_count, int],
+        min_proportion=Union[min_proportion, float],
     )
 
     @classmethod

--- a/langtest/transform/representation.py
+++ b/langtest/transform/representation.py
@@ -2,7 +2,7 @@ import asyncio
 from collections import defaultdict
 from ..errors import Errors
 from abc import ABC, abstractmethod
-from typing import List, Dict, Union
+from typing import List, Dict, TypedDict, Union
 
 from langtest.modelhandler.modelhandler import ModelAPI
 from langtest.transform.base import ITests
@@ -107,6 +107,13 @@ class BaseRepresentation(ABC):
         "translation",
     ]
 
+    # Config Hint for the representation tests
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_count=Union[int, Dict[str, int]],
+        min_proportion=Union[float, Dict[str, float]],
+    )
+
     @classmethod
     @abstractmethod
     def transform(
@@ -172,6 +179,16 @@ class GenderRepresentation(BaseRepresentation):
         "min_gender_representation_count",
         "min_gender_representation_proportion",
     ]
+
+    min_count = TypedDict("min_count", male=int, female=int, unknown=int)
+    min_proportion = TypedDict("min_proportion", male=float, female=float, unknown=float)
+
+    # Config Hint for the representation tests
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_count=Union[int, min_count],
+        min_proportion=Union[float, min_proportion],
+    )
 
     @classmethod
     def transform(
@@ -336,6 +353,32 @@ class EthnicityRepresentation(BaseRepresentation):
         "min_ethnicity_name_representation_count",
         "min_ethnicity_name_representation_proportion",
     ]
+
+    min_count = TypedDict(
+        "min_count",
+        black=int,
+        asian=int,
+        white=int,
+        native_american=int,
+        hispanic=int,
+        inter_racial=int,
+    )
+
+    min_proportion = TypedDict(
+        "min_proportion",
+        black=float,
+        asian=float,
+        white=float,
+        native_american=float,
+        hispanic=float,
+        inter_racial=float,
+    )
+
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_count=Union[int, min_count],
+        min_proportion=Union[float, min_proportion],
+    )
 
     @classmethod
     def transform(
@@ -672,6 +715,34 @@ class ReligionRepresentation(BaseRepresentation):
         "summarization",
     ]
 
+    min_count = TypedDict(
+        "min_count",
+        muslim=int,
+        hindu=int,
+        sikh=int,
+        christian=int,
+        jain=int,
+        buddhist=int,
+        parsi=int,
+    )
+
+    min_proportion = TypedDict(
+        "min_proportion",
+        muslim=float,
+        hindu=float,
+        sikh=float,
+        christian=float,
+        jain=float,
+        buddhist=float,
+        parsi=float,
+    )
+
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_count=Union[int, min_count],
+        min_proportion=Union[float, min_proportion],
+    )
+
     @classmethod
     def transform(
         cls, test: str, data: List[Sample], params: Dict
@@ -879,6 +950,28 @@ class CountryEconomicRepresentation(BaseRepresentation):
         "min_country_economic_representation_count",
         "min_country_economic_representation_proportion",
     ]
+
+    min_count = TypedDict(
+        "min_count",
+        high_income=int,
+        low_income=int,
+        lower_middle_income=int,
+        upper_middle_income=int,
+    )
+
+    min_proportion = TypedDict(
+        "min_proportion",
+        high_income=float,
+        low_income=float,
+        lower_middle_income=float,
+        upper_middle_income=float,
+    )
+
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_count=Union[int, min_count],
+        min_proportion=Union[float, min_proportion],
+    )
 
     @classmethod
     def transform(

--- a/langtest/transform/robustness.py
+++ b/langtest/transform/robustness.py
@@ -5,7 +5,7 @@ import re
 import string
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, TypedDict, Union
 
 import pandas as pd
 
@@ -294,6 +294,8 @@ class BaseRobustness(ABC):
         "translation",
     ]
 
+    TestConfig = TypedDict("TestConfig", min_pass_rate=float, prob=float)
+
     @staticmethod
     @abstractmethod
     def transform(sample_list: List[Sample]) -> List[Sample]:
@@ -357,6 +359,13 @@ class BaseRobustness(ABC):
         alias = cls.alias_name if isinstance(cls.alias_name, list) else [cls.alias_name]
         for name in alias:
             BaseRobustness.test_types[name] = cls
+
+    # class Config(TypedDict):
+    #     min_pass_rate: float
+    #     prob: float
+
+    # class Parameters(TypedDict):
+    #     ...
 
 
 class UpperCase(BaseRobustness):
@@ -495,6 +504,10 @@ class AddPunctuation(BaseRobustness):
     """A class for adding punctuation to text samples."""
 
     alias_name = "add_punctuation"
+    parameters = TypedDict("parameters", whitelist=List[str])
+    TestConfig = TypedDict(
+        "TestConfig", min_pass_rate=float, prob=float, parameters=parameters, count=int
+    )
 
     @staticmethod
     def transform(
@@ -565,6 +578,13 @@ class StripPunctuation(BaseRobustness):
     """A class for stripping punctuation to text samples."""
 
     alias_name = "strip_punctuation"
+    parameters = TypedDict("parameters", whitelist=List[str])
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+        prob=float,
+        parameters=parameters,
+    )
 
     @staticmethod
     def transform(
@@ -626,6 +646,9 @@ class AddTypo(BaseRobustness):
     """A class for adding typos to text samples."""
 
     alias_name = "add_typo"
+
+    # TestConfig
+    TestConfig = TypedDict("TestConfig", min_pass_rate=float, prob=float, count=int)
 
     @staticmethod
     def transform(
@@ -699,6 +722,14 @@ class SwapEntities(BaseRobustness):
 
     alias_name = "swap_entities"
     supported_tasks = ["ner"]
+
+    # parameters
+    parameters = TypedDict("parameters", labels=List[List[str]], count=int)
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig", min_pass_rate=float, prob=float, parameters=parameters
+    )
 
     @staticmethod
     def transform(
@@ -877,6 +908,20 @@ class AddContext(BaseRobustness):
     """A class for adding context to text samples."""
 
     alias_name = "add_context"
+
+    # additional parameters
+    parameters = TypedDict(
+        "parameters",
+        starting_context=List[str],
+        ending_context=List[str],
+        strategy=str,
+        count=int,
+    )
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig", min_pass_rate=float, prob=float, parameters=parameters
+    )
 
     @staticmethod
     def transform(
@@ -1321,6 +1366,14 @@ class AddSpeechToTextTypo(BaseRobustness):
 
     alias_name = "add_speech_to_text_typo"
 
+    # additional parameters
+    parameters = TypedDict("parameters", count=int)
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig", min_pass_rate=float, prob=float, parameters=parameters
+    )
+
     @staticmethod
     def transform(
         sample_list: List[Sample], prob: Optional[float] = 1.0, count: int = 1
@@ -1737,6 +1790,14 @@ class StripAllPunctuation(BaseRobustness):
 
     alias_name = "strip_all_punctuation"
 
+    # additional parameters
+    parameters = TypedDict("parameters", whitelist=List[str])
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig", min_pass_rate=float, prob=float, parameters=parameters
+    )
+
     @staticmethod
     def transform(
         sample_list: List[Union[Sample, str]],
@@ -1862,6 +1923,14 @@ class RandomAge(BaseRobustness):
 
     alias_name = "randomize_age"
 
+    # additional parameters
+    parameters = TypedDict("parameters", random_amount=int, count=int)
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig", min_pass_rate=float, prob=float, parameters=parameters
+    )
+
     @staticmethod
     def transform(
         sample_list: List[Sample],
@@ -1945,6 +2014,14 @@ class AddNewLines(BaseRobustness):
 
     alias_name = "add_new_lines"
     supported_tasks = ["text-classification", "question-answering", "summarization"]
+
+    # additional parameters
+    parameters = TypedDict("parameters", max_lines=int, count=int)
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig", min_pass_rate=float, prob=float, parameters=parameters
+    )
 
     @staticmethod
     def transform(
@@ -2049,6 +2126,14 @@ class AddTabs(BaseRobustness):
 
     alias_name = "add_tabs"
     supported_tasks = ["text-classification", "question-answering", "summarization"]
+
+    # additional parameters
+    parameters = TypedDict("parameters", count=int, max_tabs=int)
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig", min_pass_rate=float, prob=float, parameters=parameters
+    )
 
     @staticmethod
     def transform(

--- a/langtest/transform/robustness.py
+++ b/langtest/transform/robustness.py
@@ -259,7 +259,7 @@ class RobustnessTestFactory(ITests):
         return all_samples
 
     @staticmethod
-    def available_tests() -> dict:
+    def available_tests() -> Dict[str, type["BaseRobustness"]]:
         """
         Get a dictionary of all available tests, with their names as keys and their corresponding classes as values.
 

--- a/langtest/transform/safety.py
+++ b/langtest/transform/safety.py
@@ -1,7 +1,7 @@
 import asyncio
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Dict, List
+from typing import Dict, List, TypedDict
 
 from ..datahandler.datasource import DataFactory
 from langtest.errors import Errors
@@ -65,6 +65,12 @@ class BaseSafetyTest(ABC):
     alias_name = None
     supported_tasks = []
     registered_tests = {}
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+    )
 
     def __init__(self, data_handler: List[Sample], **kwargs) -> None:
         """Initialize a new BaseSafetyTest instance."""

--- a/langtest/transform/security.py
+++ b/langtest/transform/security.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 import asyncio
 from collections import defaultdict
-from typing import List, Dict
+from typing import List, Dict, TypedDict
 from langtest.errors import Errors
 from langtest.modelhandler.modelhandler import ModelAPI
 from langtest.transform.base import ITests
@@ -63,6 +63,12 @@ class BaseSecurity(ABC):
 
     test_types = defaultdict(lambda: BaseSecurity)
     alias_name = None
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+    )
 
     @staticmethod
     @abstractmethod

--- a/langtest/transform/sensitivity.py
+++ b/langtest/transform/sensitivity.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from langtest.transform.utils import filter_unique_samples
 from langtest.errors import Errors, Warnings
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, TypedDict
 from langtest.modelhandler import ModelAPI
 from langtest.transform.base import ITests, TestFactory
 
@@ -135,6 +135,12 @@ class BaseSensitivity(ABC):
         "sensitivity",
         "question-answering",
     ]
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+    )
 
     @staticmethod
     @abstractmethod

--- a/langtest/transform/stereoset.py
+++ b/langtest/transform/stereoset.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import List, Dict
+from typing import List, Dict, TypedDict
 from langtest.transform.base import ITests
 from langtest.modelhandler.modelhandler import ModelAPI
 from langtest.utils.custom_types.sample import Sample
@@ -13,6 +13,13 @@ class StereoSetTestFactory(ITests):
         "stereoset",
         "question-answering",
     ]
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+        diff_threshold=float,
+    )
 
     def __init__(self, data_handler: List[Sample], tests: Dict = None, **kwargs) -> None:
         """Initializes the stereoset tests"""

--- a/langtest/transform/stereotype.py
+++ b/langtest/transform/stereotype.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Union
+from typing import List, Dict, TypedDict, Union
 import asyncio
 from langtest.transform.base import ITests
 from langtest.utils.custom_types.sample import Sample
@@ -15,6 +15,14 @@ class StereoTypeTestFactory(ITests):
         "fill-mask",
         "question-answering",
     ]
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+        diff_threshold=float,
+        filter_threshold=float,
+    )
 
     def __init__(self, data_handler: List[Sample], tests: Dict = None, **kwargs) -> None:
         """Initializes the crows-pairs or wino-bias tests"""

--- a/langtest/transform/sycophancy.py
+++ b/langtest/transform/sycophancy.py
@@ -1,7 +1,7 @@
 import re
 import random
 import asyncio
-from typing import Dict, List
+from typing import Dict, List, TypedDict
 from abc import ABC, abstractmethod
 from collections import defaultdict
 
@@ -121,6 +121,12 @@ class BaseSycophancy(ABC):
         "sycophancy",
         "question-answering",
     ]
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+    )
 
     @staticmethod
     @abstractmethod

--- a/langtest/transform/toxicity.py
+++ b/langtest/transform/toxicity.py
@@ -1,7 +1,7 @@
 import asyncio
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import List, Dict
+from typing import List, Dict, TypedDict
 
 from langtest.modelhandler import ModelAPI
 from langtest.transform.base import ITests
@@ -82,6 +82,12 @@ class BaseToxicity(ABC):
 
     alias_name = None
     supported_tasks = ["toxicity", "text-generation"]
+
+    # TestConfig
+    TestConfig = TypedDict(
+        "TestConfig",
+        min_pass_rate=float,
+    )
 
     @staticmethod
     @abstractmethod

--- a/langtest/types.py
+++ b/langtest/types.py
@@ -143,6 +143,29 @@ class FairnessTestsConfig(TypedDict):
     max_gender_llm_eval: fairness.MaxGenderLLMEval.TestConfig
 
 
+class AccuracyTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Accuracy Tests.
+    """
+
+    from langtest.transform import accuracy
+
+    min_precision_score: accuracy.MinPrecisionScore.TestConfig
+    min_recall_score: accuracy.MinRecallScore.TestConfig
+    min_f1_score: accuracy.MinF1Score.TestConfig
+    min_micro_f1_score: accuracy.MinMicroF1Score.TestConfig
+    min_macro_f1_score: accuracy.MinMacroF1Score.TestConfig
+    min_weighted_f1_score: accuracy.MinWeightedF1Score.TestConfig
+    min_exact_match_score: accuracy.MinEMcore.TestConfig
+    min_bleu_score: accuracy.MinROUGEcore.TestConfig
+    min_rouge1_score: accuracy.MinROUGEcore.TestConfig
+    min_rouge2_score: accuracy.MinROUGEcore.TestConfig
+    min_rougeL_score: accuracy.MinROUGEcore.TestConfig
+    min_rougeLsum_score: accuracy.MinROUGEcore.TestConfig
+    llm_eval: accuracy.LLMEval.TestConfig
+    degradation_analysis: accuracy.DegradationAnalysis.TestConfig
+
+
 class TestCategories(TypedDict):
     """
     TestCategories is a TypedDict that defines the categories of tests.
@@ -152,6 +175,8 @@ class TestCategories(TypedDict):
     robustness: RobustnessTestsConfig
     bias: BiasTestsConfig
     representation: RepresentationTestsConfig
+    fairness: FairnessTestsConfig
+    accuracy: AccuracyTestsConfig
 
 
 class HarnessConfig(TypedDict):

--- a/langtest/types.py
+++ b/langtest/types.py
@@ -166,6 +166,21 @@ class AccuracyTestsConfig(TypedDict):
     degradation_analysis: accuracy.DegradationAnalysis.TestConfig
 
 
+class ToxicityTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Toxicity Tests.
+    """
+
+    from langtest.transform import toxicity
+
+    general_toxicity: toxicity.GeneralToxicity.TestConfig
+    obscene: toxicity.ToxicityTypes.TestConfig
+    insult: toxicity.ToxicityTypes.TestConfig
+    threat: toxicity.ToxicityTypes.TestConfig
+    identity_attack: toxicity.ToxicityTypes.TestConfig
+    homosexual_gay_or_lesbian: toxicity.ToxicityTypes.TestConfig
+
+
 class TestCategories(TypedDict):
     """
     TestCategories is a TypedDict that defines the categories of tests.
@@ -177,6 +192,7 @@ class TestCategories(TypedDict):
     representation: RepresentationTestsConfig
     fairness: FairnessTestsConfig
     accuracy: AccuracyTestsConfig
+    toxicity: ToxicityTestsConfig
 
 
 class HarnessConfig(TypedDict):

--- a/langtest/types.py
+++ b/langtest/types.py
@@ -68,3 +68,48 @@ class RobustnessTestsConfig(TypedDict):
     randomize_age: robustness.RandomAge.TestConfig
     add_new_lines: robustness.AddNewLines.TestConfig
     add_tabs: robustness.AddTabs.TestConfig
+
+
+class BiasTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Bias Tests.
+    """
+
+    from langtest.transform import bias
+
+    replace_to_male_pronouns: bias.GenderPronounBias.TestConfig
+    replace_to_female_pronouns: bias.GenderPronounBias.TestConfig
+    replace_to_neutral_pronouns: bias.GenderPronounBias.TestConfig
+    replace_to_high_income_country: bias.CountryEconomicBias.TestConfig
+    replace_to_low_income_country: bias.CountryEconomicBias.TestConfig
+    replace_to_upper_middle_income_country: bias.CountryEconomicBias.TestConfig
+    replace_to_lower_middle_income_country: bias.CountryEconomicBias.TestConfig
+    replace_to_white_firstnames: bias.EthnicityNameBias.TestConfig
+    replace_to_black_firstnames: bias.EthnicityNameBias.TestConfig
+    replace_to_hispanic_firstnames: bias.EthnicityNameBias.TestConfig
+    replace_to_asian_firstnames: bias.EthnicityNameBias.TestConfig
+    replace_to_white_lastnames: bias.EthnicityNameBias.TestConfig
+    replace_to_black_lastnames: bias.EthnicityNameBias.TestConfig
+    replace_to_hispanic_lastnames: bias.EthnicityNameBias.TestConfig
+    replace_to_asian_lastnames: bias.EthnicityNameBias.TestConfig
+    replace_to_native_american_lastnames: bias.EthnicityNameBias.TestConfig
+    replace_to_inter_racial_lastnames: bias.EthnicityNameBias.TestConfig
+    replace_to_muslim_names: bias.ReligionBias.TestConfig
+    replace_to_hindu_names: bias.ReligionBias.TestConfig
+    replace_to_christian_names: bias.ReligionBias.TestConfig
+    replace_to_sikh_names: bias.ReligionBias.TestConfig
+    replace_to_jain_names: bias.ReligionBias.TestConfig
+    replace_to_parsi_names: bias.ReligionBias.TestConfig
+    replace_to_buddhist_names: bias.ReligionBias.TestConfig
+
+
+class TestCategories(TypedDict):
+    """
+    TestCategories is a TypedDict that defines the categories of tests.
+
+    """
+
+    default = TypedDict("default", min_pass_rate=float, user_prompt=Union[str, dict])
+
+    robustness: RobustnessTestsConfig
+    bias: BiasTestsConfig

--- a/langtest/types.py
+++ b/langtest/types.py
@@ -181,6 +181,28 @@ class ToxicityTestsConfig(TypedDict):
     homosexual_gay_or_lesbian: toxicity.ToxicityTypes.TestConfig
 
 
+class SecurityTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Security Tests.
+    """
+
+    from langtest.transform import security
+
+    prompt_injection_attack: security.PromptInjection.TestConfig
+
+
+class SafetyTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Safety Tests.
+    """
+
+    from langtest.transform import safety
+
+    misuse: safety.Misuse.TestConfig
+    injection_probalities_score: safety.InjectionProbalities.TestConfig
+    jailbreak_probalities_score: safety.JailBreakProbalities.TestConfig
+
+
 class TestCategories(TypedDict):
     """
     TestCategories is a TypedDict that defines the categories of tests.
@@ -193,6 +215,7 @@ class TestCategories(TypedDict):
     fairness: FairnessTestsConfig
     accuracy: AccuracyTestsConfig
     toxicity: ToxicityTestsConfig
+    security: SecurityTestsConfig
 
 
 class HarnessConfig(TypedDict):

--- a/langtest/types.py
+++ b/langtest/types.py
@@ -203,6 +203,48 @@ class SafetyTestsConfig(TypedDict):
     jailbreak_probalities_score: safety.JailBreakProbalities.TestConfig
 
 
+class PerformanceTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Performance Tests.
+    """
+
+    from langtest.transform import performance
+
+    speed: performance.Speed.TestConfig
+
+
+class LegalTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Legal Tests.
+    """
+
+    from langtest.transform import legal
+
+    legal_support: legal.LegalTestFactory.TestConfig
+
+
+class GrammarTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Grammar Tests.
+    """
+
+    from langtest.transform import grammar
+
+    paraphase: grammar.Paraphrase.TestConfig
+
+
+class ClinicalTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Clinical Tests.
+    """
+
+    from langtest.transform import clinical
+
+    demographic_bias: clinical.DemographicBias.TestConfig
+    drug_generic_to_brand: clinical.Generic2Brand.TestConfig
+    drug_brand_to_generic: clinical.Brand2Generic.TestConfig
+
+
 class TestCategories(TypedDict):
     """
     TestCategories is a TypedDict that defines the categories of tests.
@@ -216,6 +258,11 @@ class TestCategories(TypedDict):
     accuracy: AccuracyTestsConfig
     toxicity: ToxicityTestsConfig
     security: SecurityTestsConfig
+    safety: SafetyTestsConfig
+    performance: PerformanceTestsConfig
+    legal: LegalTestsConfig
+    grammar: GrammarTestsConfig
+    clinical: ClinicalTestsConfig
 
 
 class HarnessConfig(TypedDict):

--- a/langtest/types.py
+++ b/langtest/types.py
@@ -122,6 +122,27 @@ class RepresentationTestsConfig(TypedDict):
     min_country_economic_representation_proportion: representation.CountryEconomicRepresentation.TestConfig
 
 
+class FairnessTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Fairness Tests.
+    """
+
+    from langtest.transform import fairness
+
+    min_gender_f1_score: fairness.MinGenderF1Score.TestConfig
+    max_gender_f1_score: fairness.MaxGenderF1Score.TestConfig
+    min_gender_rouge1_score: fairness.MinGenderRougeScore.TestConfig
+    min_gender_rouge2_score: fairness.MinGenderRougeScore.TestConfig
+    min_gender_rougeL_score: fairness.MinGenderRougeScore.TestConfig
+    min_gender_rougeLsum_score: fairness.MinGenderRougeScore.TestConfig
+    max_gender_rouge1_score: fairness.MaxGenderRougeScore.TestConfig
+    max_gender_rouge2_score: fairness.MaxGenderRougeScore.TestConfig
+    max_gender_rougeL_score: fairness.MaxGenderRougeScore.TestConfig
+    max_gender_rougeLsum_score: fairness.MaxGenderRougeScore.TestConfig
+    min_gender_llm_eval: fairness.MinGenderLLMEval.TestConfig
+    max_gender_llm_eval: fairness.MaxGenderLLMEval.TestConfig
+
+
 class TestCategories(TypedDict):
     """
     TestCategories is a TypedDict that defines the categories of tests.

--- a/langtest/types.py
+++ b/langtest/types.py
@@ -1,4 +1,4 @@
-from typing import Literal, TypedDict, Union, List
+from typing import Any, Dict, Literal, TypedDict, Union, List
 
 
 class ModelConfig(TypedDict):
@@ -128,8 +128,16 @@ class TestCategories(TypedDict):
 
     """
 
-    default = TypedDict("default", min_pass_rate=float, user_prompt=Union[str, dict])
-
     robustness: RobustnessTestsConfig
     bias: BiasTestsConfig
     representation: RepresentationTestsConfig
+
+
+class HarnessConfig(TypedDict):
+    """
+    HarnessConfig is a TypedDict that defines the configuration for a harness.
+    """
+
+    evaluation: Dict[str, Any]
+    model_parameters: Dict[str, Any]
+    tests: TestCategories

--- a/langtest/types.py
+++ b/langtest/types.py
@@ -35,3 +35,36 @@ class DatasetConfig(TypedDict):
     feature_column: Union[str, List[str]]
     target_column: Union[str, List[str]]
     source: str
+
+
+class RobustnessTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Robustness Tests.
+    """
+
+    from langtest.transform import robustness
+
+    uppercase: robustness.UpperCase.TestConfig
+    lowercase: robustness.LowerCase.TestConfig
+    titlecase: robustness.TitleCase.TestConfig
+    add_punctuation: robustness.AddPunctuation.TestConfig
+    strip_punctuation: robustness.StripPunctuation.TestConfig
+    add_typo: robustness.AddTypo.TestConfig
+    swap_entities: robustness.SwapEntities.TestConfig
+    american_to_british: robustness.ConvertAccent.TestConfig
+    british_to_american: robustness.ConvertAccent.TestConfig
+    add_context: robustness.AddContext.TestConfig
+    add_contractions: robustness.AddContraction.TestConfig
+    dyslexia_word_swap: robustness.DyslexiaWordSwap.TestConfig
+    number_to_word: robustness.NumberToWord.TestConfig
+    add_ocr_typo: robustness.AddOcrTypo.TestConfig
+    add_abbreviation: robustness.AbbreviationInsertion.TestConfig
+    add_speech_to_text_typo: robustness.AddSpeechToTextTypo.TestConfig
+    add_slangs: robustness.AddSlangifyTypo.TestConfig
+    multiple_perturbations: robustness.MultiplePerturbations.TestConfig
+    adjective_synonym_swap: robustness.AdjectiveSynonymSwap.TestConfig
+    adjective_antonym_swap: robustness.AdjectiveAntonymSwap.TestConfig
+    strip_all_punctuation: robustness.StripAllPunctuation.TestConfig
+    randomize_age: robustness.RandomAge.TestConfig
+    add_new_lines: robustness.AddNewLines.TestConfig
+    add_tabs: robustness.AddTabs.TestConfig

--- a/langtest/types.py
+++ b/langtest/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Literal, TypedDict, Union, List
+from typing import Any, Dict, Literal, Optional, TypedDict, Union, List
 
 
 class ModelConfig(TypedDict):
@@ -245,6 +245,80 @@ class ClinicalTestsConfig(TypedDict):
     drug_brand_to_generic: clinical.Brand2Generic.TestConfig
 
 
+class SensitivityTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Sensitivity Tests.
+    """
+
+    from langtest.transform import sensitivity
+
+    add_negation: sensitivity.AddNegation.TestConfig
+    add_toxic_words: sensitivity.AddToxicWords.TestConfig
+
+
+class SterotypeTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Sterotype Tests.
+    """
+
+    from langtest.transform import stereotype
+
+    crows_pairs: stereotype.StereoTypeTestFactory.TestConfig
+    wino_bias: stereotype.StereoTypeTestFactory.TestConfig
+
+
+class SterosetTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Steroset Tests.
+    """
+
+    from langtest.transform import stereoset
+
+    intrasentence: stereoset.StereoSetTestFactory.TestConfig
+    intersentence: stereoset.StereoSetTestFactory.TestConfig
+
+
+class SycophancyTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Sycophancy Tests.
+    """
+
+    from langtest.transform import sycophancy
+
+    sycophancy_math: sycophancy.SycophancyMath.TestConfig
+    sycophancy_nlp: sycophancy.SycophancyNlp.TestConfig
+
+
+class DisinformationTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Disinformation Tests.
+    """
+
+    from langtest.transform import disinformation
+
+    narrative_wedging: disinformation.DisinformationTestFactory.TestConfig
+
+
+class IdeologyTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Ideology Tests.
+    """
+
+    from langtest.transform import ideology
+
+    political_compass: Optional[ideology.PoliticalCompass.TestConfig]
+
+
+class FactualityTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Factuality Tests.
+    """
+
+    from langtest.transform import factuality
+
+    order_bias: factuality.FactualityTestFactory.TestConfig
+
+
 class TestCategories(TypedDict):
     """
     TestCategories is a TypedDict that defines the categories of tests.
@@ -263,6 +337,13 @@ class TestCategories(TypedDict):
     legal: LegalTestsConfig
     grammar: GrammarTestsConfig
     clinical: ClinicalTestsConfig
+    sensitivity: SensitivityTestsConfig
+    stereotype: SterotypeTestsConfig
+    stereoset: SterosetTestsConfig
+    sycophancy: SycophancyTestsConfig
+    disinformation: DisinformationTestsConfig
+    ideology: IdeologyTestsConfig
+    factuality: FactualityTestsConfig
 
 
 class HarnessConfig(TypedDict):

--- a/langtest/types.py
+++ b/langtest/types.py
@@ -103,6 +103,25 @@ class BiasTestsConfig(TypedDict):
     replace_to_buddhist_names: bias.ReligionBias.TestConfig
 
 
+class RepresentationTestsConfig(TypedDict):
+    """
+    TestsConfig is for defining the configuration of a Representation Tests.
+    """
+
+    from langtest.transform import representation
+
+    min_gender_representation_count: representation.GenderRepresentation.TestConfig
+    min_gender_representation_proportion: representation.GenderRepresentation.TestConfig
+    min_ethnicity_name_representation_count: representation.EthnicityRepresentation.TestConfig
+    min_ethnicity_name_representation_proportion: representation.EthnicityRepresentation.TestConfig
+    min_label_representation_count: representation.LabelRepresentation.TestConfig
+    min_label_representation_proportion: representation.LabelRepresentation.TestConfig
+    min_religion_name_representation_count: representation.ReligionRepresentation.TestConfig
+    min_religion_name_representation_proportion: representation.ReligionRepresentation.TestConfig
+    min_country_economic_representation_count: representation.CountryEconomicRepresentation.TestConfig
+    min_country_economic_representation_proportion: representation.CountryEconomicRepresentation.TestConfig
+
+
 class TestCategories(TypedDict):
     """
     TestCategories is a TypedDict that defines the categories of tests.
@@ -113,3 +132,4 @@ class TestCategories(TypedDict):
 
     robustness: RobustnessTestsConfig
     bias: BiasTestsConfig
+    representation: RepresentationTestsConfig


### PR DESCRIPTION
This pull request includes several changes to the `langtest` module, focusing on adding type hints, updating method signatures, and enhancing configuration options for various transformation classes. The most important changes include the introduction of `TypedDict` for configuration hints, updates to method signatures to include new types, and improvements to the representation of available tests.

### Type Hinting and Configuration Enhancements:

* [`langtest/langtest.py`](diffhunk://#diff-cfeea0c30d60dec49f5b2a632f2bed15133e4e14310610da8e8351b1f4cba4edL16-R16): Added `HarnessConfig` to the import statement and updated the `config` parameter in the `__init__` and `configure` methods to use `HarnessConfig`. [[1]](diffhunk://#diff-cfeea0c30d60dec49f5b2a632f2bed15133e4e14310610da8e8351b1f4cba4edL16-R16) [[2]](diffhunk://#diff-cfeea0c30d60dec49f5b2a632f2bed15133e4e14310610da8e8351b1f4cba4edL97-R108) [[3]](diffhunk://#diff-cfeea0c30d60dec49f5b2a632f2bed15133e4e14310610da8e8351b1f4cba4edL254-R254)

### Transformation Classes Updates:

* [`langtest/transform/accuracy.py`](diffhunk://#diff-67e53f4cd189dcacca901b1368d5fc547b66fa8fd476a51f3e994d647b8d774dR275-R279): Added `TypedDict` for `TestConfig` in `BaseAccuracy` and `LLMEval` classes to provide configuration hints. [[1]](diffhunk://#diff-67e53f4cd189dcacca901b1368d5fc547b66fa8fd476a51f3e994d647b8d774dR275-R279) [[2]](diffhunk://#diff-67e53f4cd189dcacca901b1368d5fc547b66fa8fd476a51f3e994d647b8d774dR1028-R1034)
* [`langtest/transform/bias.py`](diffhunk://#diff-4234fd86836bae5282fcadb9f8456f2ab9cf547a8ee885f08e8c66d9c711e4b2R250-R252): Introduced `TypedDict` for `TestConfig` in `BaseBias` class for bias tests configuration.
* [`langtest/transform/clinical.py`](diffhunk://#diff-d5db4d67f1083246068d8c5ceeb4ac781e70161a7724a2b283ae148875cf54a9R103-R108): Added `TypedDict` for `TestConfig` in `BaseClincial` class and updated `DemographicBias` alias names. [[1]](diffhunk://#diff-d5db4d67f1083246068d8c5ceeb4ac781e70161a7724a2b283ae148875cf54a9R103-R108) [[2]](diffhunk://#diff-d5db4d67f1083246068d8c5ceeb4ac781e70161a7724a2b283ae148875cf54a9L150-R156)
* [`langtest/transform/fairness.py`](diffhunk://#diff-51940934f178ef04e7f90edecf3d8e2722cf3fab6b62ec08d2ef127bf242387eR291-R296): Added `TypedDict` for `TestConfig` in `BaseFairness` and its subclasses to define configuration options for fairness tests. [[1]](diffhunk://#diff-51940934f178ef04e7f90edecf3d8e2722cf3fab6b62ec08d2ef127bf242387eR291-R296) [[2]](diffhunk://#diff-51940934f178ef04e7f90edecf3d8e2722cf3fab6b62ec08d2ef127bf242387eR362-R373) [[3]](diffhunk://#diff-51940934f178ef04e7f90edecf3d8e2722cf3fab6b62ec08d2ef127bf242387eR477-R488) [[4]](diffhunk://#diff-51940934f178ef04e7f90edecf3d8e2722cf3fab6b62ec08d2ef127bf242387eR600-R611) [[5]](diffhunk://#diff-51940934f178ef04e7f90edecf3d8e2722cf3fab6b62ec08d2ef127bf242387eR721-R732) [[6]](diffhunk://#diff-51940934f178ef04e7f90edecf3d8e2722cf3fab6b62ec08d2ef127bf242387eR836-R847) [[7]](diffhunk://#diff-51940934f178ef04e7f90edecf3d8e2722cf3fab6b62ec08d2ef127bf242387eR984-R995)
* [`langtest/transform/grammar.py`](diffhunk://#diff-a64d03e7c6535885fa9bb8ff145f990a9efbcfd411e0fcf18bc72fad1f587be1L2-R2): Introduced `TypedDict` for `TestConfig` in `BaseGrammar` class and updated `available_tests` method signature. [[1]](diffhunk://#diff-a64d03e7c6535885fa9bb8ff145f990a9efbcfd411e0fcf18bc72fad1f587be1L2-R2) [[2]](diffhunk://#diff-a64d03e7c6535885fa9bb8ff145f990a9efbcfd411e0fcf18bc72fad1f587be1L106-R106) [[3]](diffhunk://#diff-a64d03e7c6535885fa9bb8ff145f990a9efbcfd411e0fcf18bc72fad1f587be1R123-R139)
* [`langtest/transform/legal.py`](diffhunk://#diff-f9d5369197d6dd2057f38dde3a2b86acc0504805719a3ace0f7666247b6ab257L2-R2): Added `TypedDict` for `TestConfig` in `LegalTestFactory` class for legal tests configuration. [[1]](diffhunk://#diff-f9d5369197d6dd2057f38dde3a2b86acc0504805719a3ace0f7666247b6ab257L2-R2) [[2]](diffhunk://#diff-f9d5369197d6dd2057f38dde3a2b86acc0504805719a3ace0f7666247b6ab257R14-R19)
* [`langtest/transform/performance.py`](diffhunk://#diff-0115e79614cd36509e8ac77c9cd58976b4486bd471a995ae234d8b7ea453b60cL4-R4): Introduced `TypedDict` for `TestConfig` in `BasePerformance` class and updated `available_tests` method signature. [[1]](diffhunk://#diff-0115e79614cd36509e8ac77c9cd58976b4486bd471a995ae234d8b7ea453b60cL4-R4) [[2]](diffhunk://#diff-0115e79614cd36509e8ac77c9cd58976b4486bd471a995ae234d8b7ea453b60cL76-R76) [[3]](diffhunk://#diff-0115e79614cd36509e8ac77c9cd58976b4486bd471a995ae234d8b7ea453b60cR99-R104)
* [`langtest/transform/representation.py`](diffhunk://#diff-f64d2d0c20473476f8f9fb7946891149e627d6a29871d2304504582b10c3f866L5-R5): Added `TypedDict` for `TestConfig` in `BaseRepresentation` and its subclasses to define configuration options for representation tests. [[1]](diffhunk://#diff-f64d2d0c20473476f8f9fb7946891149e627d6a29871d2304504582b10c3f866L5-R5) [[2]](diffhunk://#diff-f64d2d0c20473476f8f9fb7946891149e627d6a29871d2304504582b10c3f866L77-R77) [[3]](diffhunk://#diff-f64d2d0c20473476f8f9fb7946891149e627d6a29871d2304504582b10c3f866R110-R116) [[4]](diffhunk://#diff-f64d2d0c20473476f8f9fb7946891149e627d6a29871d2304504582b10c3f866R183-R192) [[5]](diffhunk://#diff-f64d2d0c20473476f8f9fb7946891149e627d6a29871d2304504582b10c3f866R357-R382)