### PR TITLE
fix: improve model_report function to handle numeric values and initi…

### DIFF
--- a/langtest/utils/report_utils.py
+++ b/langtest/utils/report_utils.py
@@ -157,7 +157,7 @@ def model_report(
 
         # handling multiple keys in the dictionary like (true or false), (score_1, score_2, score_3)
         record_count = sum(
-            num for num in test_values.values() if isinstance(num, (int, float))
+            int(num) for num in test_values.values() if isinstance(num, (int, float))
         )
         # record_count = test_values["total"]
 
@@ -190,6 +190,12 @@ def model_report(
                             "pass": ispass,
                         }
                     )
+
+            if "pass_count" not in temp:
+                temp["pass_count"] = 0
+
+            if "fail_count" not in temp:
+                temp["fail_count"] = 0
 
         report[test_type] = temp
 


### PR DESCRIPTION
This pull request includes changes to the `langtest/utils/report_utils.py` file to improve the handling of dictionary keys and ensure the presence of specific keys in the generated report. The most important changes include modifying the way numerical values are summed and adding default values for missing keys.

Improvements to handling dictionary keys:

* [`langtest/utils/report_utils.py`](diffhunk://#diff-1e2a2b8476b167c5bdbd61adc61f63a83bdd61eb869118bee6ac451725967993L160-R160): Modified the summation of numerical values to ensure they are cast to integers.

Ensuring presence of specific keys:

* [`langtest/utils/report_utils.py`](diffhunk://#diff-1e2a2b8476b167c5bdbd61adc61f63a83bdd61eb869118bee6ac451725967993R194-R199): Added default values for `pass_count` and `fail_count` keys if they are not present in the temporary dictionary.