### PR TITLE
feat: update dependency version constraints in pyproject.toml 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,11 +60,11 @@ huggingface_hub = { version = ">0.16.0", optional = true}
 spacy = { version = ">=3.0.0", optional = true }
 nest-asyncio = "^1.5.0"
 openai = "^1.40.6"
-jsonlines = "^3.1.0"
+jsonlines = ">=3.1.0"
 torch = { version = "^2.0.0", optional = true }
 pandas = "^2.0.3"
 pyyaml = "^6.0"
-tqdm = "^4.65.0"
+tqdm = ">=4.65.0"
 cohere = { version = "^4.10.0", optional = true}
 ai21 = {version = "^1.1.0", optional = true}
 metaflow = {version = ">=2.9.0", optional = true}
@@ -79,10 +79,10 @@ typing-extensions = "^4.10.0"
 langchain-openai = {version = "0.2.5", optional = true}
 boto3 = {version = "^1.34.93", optional = true}
 importlib-resources = "^6.4.0"
-click = "^8.1.7"
-openpyxl = "^3.1.5"
-tables = "3.8.0"
-pillow = "^11.0.0"
+click = ">=8.1.7"
+openpyxl = ">=3.1.5"
+tables = ">=3.8.0"
+pillow = ">=11.0.0"
 langchain-databricks = {version = "0.1.1", optional = true}
 langchain-community = {version = "0.3.5", optional = true}
 


### PR DESCRIPTION
This pull request includes changes to the `pyproject.toml` file to update the version constraints for several dependencies. These updates ensure compatibility with a broader range of versions.

Dependency version updates:

* Changed `jsonlines` version constraint from `^3.1.0` to `>=3.1.0` to allow for newer versions.
* Changed `tqdm` version constraint from `^4.65.0` to `>=4.65.0` to allow for newer versions.
* Changed `click` version constraint from `^8.1.7` to `>=8.1.7` to allow for newer versions.
* Changed `openpyxl` version constraint from `^3.1.5` to `>=3.1.5` to allow for newer versions.
* Changed `tables` version constraint from `3.8.0` to `>=3.8.0` to allow for newer versions.
* Changed `pillow` version constraint from `^11.0.0` to `>=11.0.0` to allow for newer versions.