### PR TITLE
bump version to 2.5.0 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langtest"
-version = "2.4.0"
+version = "2.5.0"
 description = "John Snow Labs provides a library for delivering safe & effective NLP models."
 authors = ["John Snow Labs <support@johnsnowlabs.com>"]
 readme = "README.md"


### PR DESCRIPTION
This pull request includes a version update for the `langtest` package. The version has been incremented from `2.4.0` to `2.5.0`.

Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the `langtest` package version from `2.4.0` to `2.5.0`.