### PR TITLE
feat: add support for question answering model in JSL model handler

### DIFF
--- a/langtest/modelhandler/jsl_modelhandler.py
+++ b/langtest/modelhandler/jsl_modelhandler.py
@@ -107,6 +107,7 @@ if try_import_lib("sparknlp_jsl"):
         MedicalDistilBertForSequenceClassification,
         MedicalQuestionAnswering,
         MedicalSummarizer,
+        ExtractiveSummarization,
         MedicalTextGenerator,
     )
 
@@ -134,7 +135,10 @@ if try_import_lib("sparknlp_jsl"):
 
     SUPPORTED_SPARKNLP_QA = [MedicalQuestionAnswering]
 
-    SUPPORTED_SPARKNLP_SUMMARIZATION = [MedicalSummarizer]
+    SUPPORTED_SPARKNLP_SUMMARIZATION = [
+        MedicalSummarizer,
+        ExtractiveSummarization,
+    ]
 
     SUPPORTED_SPARKNLP_TEXT_GENERATION = [MedicalTextGenerator]
 


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `langtest/modelhandler/jsl_modelhandler.py` file. The changes include adding support for a new model type, updating method signatures, and improving the handling of input data.

### New Model Support:
* Added `MedicalQuestionAnswering` to the list of supported models and created a new `PretrainedModelForQA` class to handle question-answering tasks. This includes methods for initializing the model, checking if a model instance is supported, and performing predictions. [[1]](diffhunk://#diff-b89362e1c25807c7dab47fdf18e34f91743b7cb70bc7aeb1b9a3731d855cb545R107) [[2]](diffhunk://#diff-b89362e1c25807c7dab47fdf18e34f91743b7cb70bc7aeb1b9a3731d855cb545R132-R133) [[3]](diffhunk://#diff-b89362e1c25807c7dab47fdf18e34f91743b7cb70bc7aeb1b9a3731d855cb545R567-R642)

### Method Signature Updates:
* Updated the `__call__` method in `PretrainedJSLModel` to accept additional arguments (`*args` and `**kwargs`) and handle dictionary inputs by converting them to `HashableDict`.

### Utility Imports:
* Imported `HashableDict` from `langtest.utils.custom_types.helpers` to facilitate the handling of dictionary inputs in the `__call__` method.

These changes enhance the flexibility and functionality of the model handler, particularly for question-answering tasks.