### PR TITLE
feat: add support for generating templates using Ollama provider

### DIFF
--- a/langtest/augmentation/base.py
+++ b/langtest/augmentation/base.py
@@ -361,7 +361,7 @@ class TemplaticAugment(BaseAugmentaion):
                 raise ImportError(Errors.E097())
 
             except Exception as e_msg:
-                raise Errors.E095(e=e_msg)
+                raise Exception(Errors.E095(e=e_msg))
 
         if show_templates:
             [print(template) for template in self.__templates]

--- a/langtest/augmentation/base.py
+++ b/langtest/augmentation/base.py
@@ -610,6 +610,7 @@ class TemplaticAugment(BaseAugmentaion):
         from langtest.augmentation.utils import (
             generate_templates_azoi,  # azoi means Azure OpenAI
             generate_templates_openai,
+            generate_templates_ollama,
         )
 
         params = model_config.copy() if model_config else {}
@@ -619,6 +620,9 @@ class TemplaticAugment(BaseAugmentaion):
 
         elif model_config and model_config.get("provider") == "azure":
             return generate_templates_azoi(template, num_extra_templates, params)
+
+        elif model_config and model_config.get("provider") == "ollama":
+            return generate_templates_ollama(template, num_extra_templates, params)
 
         else:
             return generate_templates_openai(template, num_extra_templates)

--- a/langtest/augmentation/base.py
+++ b/langtest/augmentation/base.py
@@ -361,7 +361,8 @@ class TemplaticAugment(BaseAugmentaion):
                 raise ImportError(Errors.E097())
 
             except Exception as e_msg:
-                raise Exception(Errors.E095(e=e_msg))
+                error_message = str(e_msg)
+                raise Exception(Errors.E095(e=error_message))
 
         if show_templates:
             [print(template) for template in self.__templates]

--- a/langtest/augmentation/utils.py
+++ b/langtest/augmentation/utils.py
@@ -85,6 +85,8 @@ def generate_templates_azoi(
 
     if "provider" in model_config:
         del model_config["provider"]
+
+    if "model" in model_config:
         del model_config["model"]
 
     client = openai.AzureOpenAI(**model_config)
@@ -151,6 +153,8 @@ def generate_templates_openai(
 
     if "provider" in model_config:
         del model_config["provider"]
+
+    if "model" in model_config:
         del model_config["model"]
 
     client = openai.OpenAI(**model_config)
@@ -177,6 +181,49 @@ def generate_templates_openai(
     )
 
     generated_response = response.choices[0].message.parsed
+    generated_response.remove_invalid_templates(template)
+
+    return generated_response.templates[:num_extra_templates]
+
+
+def generate_templates_ollama(
+    template: str, num_extra_templates: int, model_config: OpenAIConfig = OpenAIConfig()
+):
+    """Generate new templates based on the provided template using OpenAI API."""
+
+    import ollama
+
+    model_name = model_config.get("model", "gpt-4o-mini")
+
+    if "provider" in model_config:
+        del model_config["provider"]
+
+    if "model" in model_config:
+        del model_config["model"]
+
+    client = ollama.Client()
+
+    prompt = (
+        f"Based on the provided template, create {num_extra_templates} new and unique templates that are "
+        "variations on this theme. Present these as a list, with each template as a quoted string. The list should "
+        "contain only the templates, without any additional text or explanation. Ensure that the structure of "
+        "these variables remains consistent in each generated template. Note: don't add any extra variables and ignore typo errors.\n\n"
+        "Template:\n"
+        f"{template}\n"
+    )
+    response = client.chat(
+        model=model_name,
+        messages=[
+            {
+                "role": "system",
+                "content": f"Action: Generate up to {num_extra_templates} templates and ensure that the structure of the variables within the templates remains unchanged and don't add any extra variables.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+        format=Templates.model_json_schema(),
+    )
+
+    generated_response = Templates.model_validate_json(response.message.content)
     generated_response.remove_invalid_templates(template)
 
     return generated_response.templates[:num_extra_templates]

--- a/langtest/augmentation/utils.py
+++ b/langtest/augmentation/utils.py
@@ -189,7 +189,7 @@ def generate_templates_openai(
 def generate_templates_ollama(
     template: str, num_extra_templates: int, model_config: OpenAIConfig = OpenAIConfig()
 ):
-    """Generate new templates based on the provided template using OpenAI API."""
+    """Generate new templates based on the provided template using Ollama API."""
     import ollama
 
     # model_name

--- a/langtest/augmentation/utils.py
+++ b/langtest/augmentation/utils.py
@@ -190,40 +190,46 @@ def generate_templates_ollama(
     template: str, num_extra_templates: int, model_config: OpenAIConfig = OpenAIConfig()
 ):
     """Generate new templates based on the provided template using OpenAI API."""
-
     import ollama
 
-    model_name = model_config.get("model", "gpt-4o-mini")
+    # model_name
+    model_name = model_config.get("model", "llama3.1")
+    try:
 
-    if "provider" in model_config:
-        del model_config["provider"]
+        if "provider" in model_config:
+            del model_config["provider"]
 
-    if "model" in model_config:
-        del model_config["model"]
+        if "model" in model_config:
+            del model_config["model"]
 
-    client = ollama.Client()
+        client = ollama.Client()
 
-    prompt = (
-        f"Based on the provided template, create {num_extra_templates} new and unique templates that are "
-        "variations on this theme. Present these as a list, with each template as a quoted string. The list should "
-        "contain only the templates, without any additional text or explanation. Ensure that the structure of "
-        "these variables remains consistent in each generated template. Note: don't add any extra variables and ignore typo errors.\n\n"
-        "Template:\n"
-        f"{template}\n"
-    )
-    response = client.chat(
-        model=model_name,
-        messages=[
-            {
-                "role": "system",
-                "content": f"Action: Generate up to {num_extra_templates} templates and ensure that the structure of the variables within the templates remains unchanged and don't add any extra variables.",
-            },
-            {"role": "user", "content": prompt},
-        ],
-        format=Templates.model_json_schema(),
-    )
+        prompt = (
+            f"Based on the provided template, create {num_extra_templates} new and unique templates that are "
+            "variations on this theme. Present these as a list, with each template as a quoted string. The list should "
+            "contain only the templates, without any additional text or explanation. Ensure that the structure of "
+            "these variables remains consistent in each generated template. Note: don't add any extra variables and ignore typo errors.\n\n"
+            "Template:\n"
+            f"{template}\n"
+        )
+        response = client.chat(
+            model=model_name,
+            messages=[
+                {
+                    "role": "system",
+                    "content": f"Action: Generate up to {num_extra_templates} templates and ensure that the structure of the variables within the templates remains unchanged and don't add any extra variables.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+            format=Templates.model_json_schema(),
+        )
 
-    generated_response = Templates.model_validate_json(response.message.content)
-    generated_response.remove_invalid_templates(template)
-
-    return generated_response.templates[:num_extra_templates]
+        generated_response = Templates.model_validate_json(response.message.content)
+        generated_response.remove_invalid_templates(template)
+        return generated_response.templates[:num_extra_templates]
+    except ollama.ResponseError as e:
+        if any("model" in arg for arg in e.args):
+            raise ValueError(
+                f"Model not found: {e}, please pull model using `ollama pull {model_name}`"
+            )
+        raise ValueError(f"Error in response: {e}")


### PR DESCRIPTION

This pull request adds support for generating templates using the Ollama API in the `langtest` package. The changes include adding a new function to handle template generation with Ollama, updating the template generation logic to include the new provider, and making minor adjustments to existing functions.

**Key changes:**

* **Support for Ollama API:**
  * Added `generate_templates_ollama` function to `langtest/augmentation/utils.py` to handle template generation using the Ollama API.
  * Updated `__generate_templates` function in `langtest/augmentation/base.py` to include the Ollama provider. [[1]](diffhunk://#diff-98f1b386e193db1bfc9b46d9d681af5af29ba450fd3cd65629033e57b5ecffd9R613) [[2]](diffhunk://#diff-98f1b386e193db1bfc9b46d9d681af5af29ba450fd3cd65629033e57b5ecffd9R624-R626)

* **Minor adjustments to existing functions:**
  * Modified `generate_templates_azoi` and `generate_templates_openai` functions to remove the "model" key from `model_config` if it exists. [[1]](diffhunk://#diff-8b76961c03149f843a12e26ca64e5e75ff310bc2a4f5be5fe1b4d0cd3304c49fR88-R89) [[2]](diffhunk://#diff-8b76961c03149f843a12e26ca64e5e75ff310bc2a4f5be5fe1b4d0cd3304c49fR156-R157)
---
### Issues: 

- #1179 
