### PR TITLE
fix: embedding based evaluation using openai sdk

### DIFF
--- a/langtest/embeddings/openai.py
+++ b/langtest/embeddings/openai.py
@@ -10,7 +10,7 @@ from ..errors import Errors
 class OpenaiEmbeddings:
     LIB_NAME = "openai"
 
-    def __init__(self, model="text-embedding-ada-002"):
+    def __init__(self, model="text-embedding-3-small"):
         self.model = model
         self.api_key = os.environ.get("OPENAI_API_KEY")
         self.openai = None
@@ -18,7 +18,7 @@ class OpenaiEmbeddings:
         if not self.api_key:
             raise ValueError(Errors.E032())
 
-        self.openai.api_key = self.api_key
+        # self.openai.api_key = self.api_key
 
     def _check_openai_package(self):
         """Check if the 'openai' package is installed and import the required functions.
@@ -44,13 +44,13 @@ class OpenaiEmbeddings:
             list[float]: A list of floating-point values representing the text's embedding.
         """
         if isinstance(text, list):
-            response = self.openai.Embedding.create(input=text, model=self.model)
+            response = self.openai.Client(api_key=self.api_key).embedding.create(input=text, model=self.model)
             embedding = [
-                np.array(response["data"][i]["embedding"]).reshape(1, -1)
+                np.array(response.data[i].embedding).reshape(1, -1)
                 for i in range(len(text))
             ]
             return embedding
         else:
-            response = self.openai.Embedding.create(input=[text], model=self.model)
-            embedding = np.array(response["data"][0]["embedding"]).reshape(1, -1)
+            response = self.openai.Client(api_key=self.api_key).embedding.create(input=[text], model=self.model)
+            embedding = np.array(response.data[0].embedding).reshape(1, -1)
             return embedding

--- a/langtest/embeddings/openai.py
+++ b/langtest/embeddings/openai.py
@@ -44,13 +44,17 @@ class OpenaiEmbeddings:
             list[float]: A list of floating-point values representing the text's embedding.
         """
         if isinstance(text, list):
-            response = self.openai.Client(api_key=self.api_key).embedding.create(input=text, model=self.model)
+            response = self.openai.Client(api_key=self.api_key).embedding.create(
+                input=text, model=self.model
+            )
             embedding = [
                 np.array(response.data[i].embedding).reshape(1, -1)
                 for i in range(len(text))
             ]
             return embedding
         else:
-            response = self.openai.Client(api_key=self.api_key).embedding.create(input=[text], model=self.model)
+            response = self.openai.Client(api_key=self.api_key).embedding.create(
+                input=[text], model=self.model
+            )
             embedding = np.array(response.data[0].embedding).reshape(1, -1)
             return embedding


### PR DESCRIPTION
This pull request updates the OpenAI embeddings integration to use the latest API client pattern and a newer embedding model. The changes primarily modernize how the OpenAI API is called and update the default model for generating embeddings.

OpenAI API integration updates:

* Updated the default embedding model from `text-embedding-ada-002` to `text-embedding-3-small` in the `OpenaiEmbeddings` class constructor.
* Changed API calls to use the new `openai.Client` class with explicit API key passing, rather than setting `api_key` directly on the module. This affects both batch and single text embedding requests in the `get_embedding` method.
* Updated the response parsing to match the new API response structure (accessing `response.data[i].embedding` instead of `response["data"][i]["embedding"]`).